### PR TITLE
fix: honour dark mode on Android 12+ splash screen

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="color_splash_background">#121212</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ic_launcher_background">#1B5E3A</color>
+    <color name="color_splash_background">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/styles_sgit.xml
+++ b/app/src/main/res/values/styles_sgit.xml
@@ -18,9 +18,12 @@
         <item type="drawable" name="ic_branch_l">@drawable/ic_branch_d</item>
         <item type="drawable" name="ic_tag_l">@drawable/ic_tag_d</item>
 
-        <!-- this strangely fixes the "flash" of the default light theme on app startup when the
-          dark theme is selected, from: http://stackoverflow.com/a/29202453/85472 -->
+        <!-- fixes the "flash" of the default light theme on app startup when the dark theme is
+          selected on pre-12 devices, from: http://stackoverflow.com/a/29202453/85472 -->
         <item name="android:windowDisablePreview">true</item>
+        <!-- on Android 12+ the system enforces a splash screen; windowDisablePreview no longer
+          suppresses it, so set the background explicitly to a night-mode-aware color instead -->
+        <item name="android:windowSplashScreenBackground">@color/color_splash_background</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Fixes #3

## Summary

Android 12+ enforces a mandatory splash screen whose background comes from `android:windowSplashScreenBackground` in the launch theme. Without it, the system falls back to the theme's `colorBackground` (white for the light `AppTheme`), causing a bright flash on cold launch in dark mode. Added a night-mode-aware `color_splash_background` color (`#FFFFFF` light, `#121212` dark) and set `android:windowSplashScreenBackground` in `Theme.Sgit`. Pre-12 devices are unaffected, since `windowDisablePreview` already suppresses the preview window there.

## Demo

**Before** (bright flash on dark-mode cold launch):

<img width="360" height="800" alt="splash_light" src="https://github.com/user-attachments/assets/bb0293f3-b3b2-4450-9e1a-dd3b88d35b5e" />


**After** (dark splash, no flash):

<img width="360" height="800" alt="splash_dark" src="https://github.com/user-attachments/assets/749e0b8e-a7eb-465e-acba-01277b6d7994" />


## Test plan

- [ ] Cold launch on Android 12+ emulator in dark mode — splash background dark, no bright flash
- [ ] Cold launch on Android 12+ emulator in light mode — splash background white, no regression