### PR TITLE
feat: add monochrome adaptive icon for Android 13+ theming

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Closes #2

## Summary

Adds a `<monochrome>` layer to both adaptive icon XMLs (`ic_launcher.xml` and `ic_launcher_round.xml`), pointing at the existing `ic_launcher_foreground` drawable. The foreground is already a single-colour vector on a transparent background, which is exactly what the monochrome spec requires — no new drawable needed. Android 13+ launchers with themed icons enabled will use this layer to render a tinted version of the icon that matches the system accent colour.

## Screenshot

Adaptive icon rendering on Android 16 (App info):

<img width="500" height="500" alt="gitling_monochrome_icon" src="https://github.com/user-attachments/assets/5493f73d-4e4d-4cfe-beb6-99082430b934" />

## Test plan

- [x] On Android 13+ device/emulator with Themed icons enabled — icon adopts the system accent colour on the home screen
- [x] On Android 12 and below — no change, `<monochrome>` layer is silently ignored