### PR TITLE
feat: add Submodule Update action and fix clone-recursively checkbox

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repodetail/RepoDetailScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repodetail/RepoDetailScreen.kt
@@ -290,7 +290,8 @@ fun RepoOperationList(onOperationClick: (index: Int) -> Unit) {
         "Remove Remote" to Icons.Default.LinkOff,
         "Delete" to Icons.Default.Delete,
         "Raw Config" to Icons.Default.Code,
-        "Options" to Icons.Default.Settings
+        "Options" to Icons.Default.Settings,
+        "Submodule Update" to Icons.Default.AccountTree
     )
 
     Column(modifier = Modifier.verticalScroll(rememberScrollState())) {

--- a/app/src/main/java/com/manichord/mgit/repolist/CloneView.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/CloneView.kt
@@ -37,7 +37,7 @@ fun CloneView(
     var remoteUrl by remember(viewModel.remoteUrl) { mutableStateOf(viewModel.remoteUrl) }
     val localRepoName by viewModel.localRepoName.observeAsState("")
     val initLocal by viewModel.initLocal.observeAsState(false)
-    val cloneRecursively by remember { mutableStateOf(viewModel.cloneRecursively) }
+    var cloneRecursively by remember { mutableStateOf(viewModel.cloneRecursively) }
 
     val remoteUrlError by viewModel.remoteUrlError.observeAsState()
     val localRepoNameError by viewModel.localRepoNameError.observeAsState()
@@ -187,7 +187,7 @@ fun CloneView(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Checkbox(
                             checked = cloneRecursively,
-                            onCheckedChange = { viewModel.cloneRecursively = it }
+                            onCheckedChange = { cloneRecursively = it; viewModel.cloneRecursively = it }
                         )
                         Text(
                             text = stringResource(id = R.string.dialog_clone_recursive),

--- a/app/src/main/java/me/sheimi/sgit/activities/delegate/RepoOperationDelegate.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/delegate/RepoOperationDelegate.java
@@ -28,6 +28,7 @@ import me.sheimi.sgit.activities.delegate.actions.RebaseAction;
 import me.sheimi.sgit.activities.delegate.actions.RemoveRemoteAction;
 import me.sheimi.sgit.activities.delegate.actions.RepoAction;
 import me.sheimi.sgit.activities.delegate.actions.ResetAction;
+import me.sheimi.sgit.activities.delegate.actions.SubmoduleUpdateAction;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.repo.tasks.SheimiAsyncTask.AsyncTaskPostCallback;
 import me.sheimi.sgit.repo.tasks.repo.AddToStageTask;
@@ -68,6 +69,7 @@ public class RepoOperationDelegate {
         mActions.add(new DeleteAction(mRepo, mActivity));
         mActions.add(new RawConfigAction(mRepo, mActivity));
         mActions.add(new ConfigAction(mRepo, mActivity));
+        mActions.add(new SubmoduleUpdateAction(mRepo, mActivity));
     }
 
     public void executeAction(int key) {

--- a/app/src/main/java/me/sheimi/sgit/activities/delegate/actions/SubmoduleUpdateAction.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/delegate/actions/SubmoduleUpdateAction.java
@@ -1,0 +1,18 @@
+package me.sheimi.sgit.activities.delegate.actions;
+
+import me.sheimi.sgit.activities.RepoDetailActivity;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.repo.tasks.repo.SubmoduleUpdateTask;
+
+public class SubmoduleUpdateAction extends RepoAction {
+
+    public SubmoduleUpdateAction(Repo repo, RepoDetailActivity activity) {
+        super(repo, activity);
+    }
+
+    @Override
+    public void execute() {
+        new SubmoduleUpdateTask(mRepo, null).executeTask();
+        mActivity.closeOperationDrawer();
+    }
+}

--- a/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/SubmoduleUpdateTask.java
+++ b/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/SubmoduleUpdateTask.java
@@ -1,0 +1,55 @@
+package me.sheimi.sgit.repo.tasks.repo;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.SubmoduleInitCommand;
+import org.eclipse.jgit.api.SubmoduleUpdateCommand;
+
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.exception.StopTaskException;
+
+public class SubmoduleUpdateTask extends RepoOpTask {
+
+    private final AsyncTaskCallback mCallback;
+
+    public SubmoduleUpdateTask(Repo repo, AsyncTaskCallback callback) {
+        super(repo);
+        mCallback = callback;
+    }
+
+    @Override
+    protected Boolean doInBackground(Void... params) {
+        Git git;
+        try {
+            git = mRepo.getGit();
+        } catch (StopTaskException e) {
+            return false;
+        }
+
+        try {
+            new SubmoduleInitCommand(git.getRepository()).call();
+            new SubmoduleUpdateCommand(git.getRepository()).call();
+        } catch (Exception e) {
+            setException(e, R.string.error_submodule_update_failed);
+            return false;
+        } catch (OutOfMemoryError e) {
+            setException(e, R.string.error_out_of_memory);
+            return false;
+        }
+
+        setSuccessMsg(R.string.toast_submodule_update_success);
+
+        if (mCallback != null) {
+            mCallback.doInBackground(params);
+        }
+        return true;
+    }
+
+    @Override
+    protected void onPostExecute(Boolean isSuccess) {
+        super.onPostExecute(isSuccess);
+        if (mCallback != null) {
+            mCallback.onPostExecute(isSuccess);
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,4 +210,5 @@
     <string name="preference_eng_lang">English Language</string>
     <string name="preference_eng_lang_summary">Use English instead of the default language</string>
     <string name="pref_key_use_english" translatable="false">use.english</string>
+    <string name="toast_submodule_update_success">Submodules updated</string>
 </resources>

--- a/app/src/main/res/values/strings_error.xml
+++ b/app/src/main/res/values/strings_error.xml
@@ -49,5 +49,6 @@
     <string name="alert_save_failed">Save failed</string>
     <string name="alert_file_creation_failure">Couldn\'t create file</string>
     <string name="error_no_repository">No repository found</string>
+    <string name="error_submodule_update_failed">Submodule update failed</string>
 
 </resources>


### PR DESCRIPTION
Closes #6

## Summary

- **New action — Submodule Update:** adds a "Submodule Update" entry to the repo operation drawer. Tapping it runs `git submodule init && git submodule update` via JGit's `SubmoduleInitCommand` + `SubmoduleUpdateCommand`. Handles the case where a new submodule was added to a remote repo after the local clone already existed — previously those submodule directories would silently remain empty after a pull.
- **Bug fix — Clone recursively checkbox:** the checkbox state was declared `val` instead of `var`, so ticking it updated the ViewModel but the checkbox never visually toggled. Fixed by declaring the state as `var` and updating it alongside the ViewModel in `onCheckedChange`.

## Files changed

| File | Change |
|---|---|
| `SubmoduleUpdateTask.java` | New JGit task — init + update all submodules |
| `SubmoduleUpdateAction.java` | New delegate action — wires task to the drawer |
| `RepoOperationDelegate.java` | Registers `SubmoduleUpdateAction` at end of action list |
| `RepoDetailScreen.kt` | Adds "Submodule Update" entry to `RepoOperationList` composable |
| `CloneView.kt` | Fixes `val` → `var` for clone-recursively checkbox state |
| `strings.xml` | Adds `toast_submodule_update_success` |
| `strings_error.xml` | Adds `error_submodule_update_failed` |

## Test plan

- [ ] Repo with no submodules — "Submodule Update" completes silently with success toast
- [ ] Repo cloned without `--recurse-submodules` that has submodules — tapping Submodule Update initialises and populates them
- [ ] Clone dialog — "Clone recursively" checkbox toggles visually when tapped