### PR TITLE
fix: persist GitHub banner dismissal across app resumes

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
@@ -24,6 +24,7 @@ import com.manichord.mgit.whatsnew.WhatsNewContent
 import com.manichord.mgit.whatsnew.WhatsNewDialog
 import me.sheimi.android.activities.SheimiFragmentActivity
 import me.sheimi.android.utils.Profile
+import androidx.compose.runtime.saveable.rememberSaveable
 import me.sheimi.sgit.BuildConfig
 import me.sheimi.sgit.MGitApplication
 import me.sheimi.sgit.R
@@ -61,6 +62,10 @@ fun RepoListComposeContent(
         var deleteTarget by remember { mutableStateOf<Repo?>(null) }
 
         val context = LocalContext.current
+        var githubBannerDismissed by rememberSaveable {
+            mutableStateOf(Profile.getGitHubBannerDismissed(context))
+        }
+
         var whatsNewEntries by remember {
             mutableStateOf(run {
                 val lastSeen = Profile.getLastSeenVersionCode(context)
@@ -80,6 +85,11 @@ fun RepoListComposeContent(
         RepoListScreen(
             repoList = repoListSnapshot,
             isGitHubConnected = isGitHubConnected,
+            githubBannerDismissed = githubBannerDismissed,
+            onDismissGitHubBanner = {
+                githubBannerDismissed = true
+                Profile.setGitHubBannerDismissed(context, true)
+            },
             onRepoClick = { repo ->
                 (activity as com.manichord.mgit.MainActivity).openRepoDetail(repo)
             },

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
@@ -43,6 +43,8 @@ private fun Repo.matchesSearch(query: String): Boolean {
 fun RepoListScreen(
     repoList: List<Repo>,
     isGitHubConnected: Boolean,
+    githubBannerDismissed: Boolean,
+    onDismissGitHubBanner: () -> Unit,
     onRepoClick: (Repo) -> Unit,
     onRepoLongClick: (Repo) -> Unit,
     onCloneClick: () -> Unit,
@@ -52,7 +54,6 @@ fun RepoListScreen(
     onViewReleaseClick: () -> Unit = {},
     onDismissUpdateClick: () -> Unit = {}
 ) {
-    var githubBannerDismissed by remember { mutableStateOf(false) }
     var isSearchActive by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
     val searchFocusRequester = remember { FocusRequester() }
@@ -145,7 +146,7 @@ fun RepoListScreen(
             if (!isGitHubConnected && !githubBannerDismissed && repoList.isNotEmpty()) {
                 ConnectGitHubBanner(
                     onConnectClick = onConnectGitHubClick,
-                    onDismissClick = { githubBannerDismissed = true }
+                    onDismissClick = onDismissGitHubBanner
                 )
             }
             Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/me/sheimi/android/utils/Profile.java
+++ b/app/src/main/java/me/sheimi/android/utils/Profile.java
@@ -164,4 +164,14 @@ public class Profile {
         String key = context.getString(R.string.pref_key_pending_storage_migration_notice);
         getProfileSharedPreference(context).edit().putBoolean(key, pending).apply();
     }
+
+    public static boolean getGitHubBannerDismissed(Context context) {
+        String key = context.getString(R.string.pref_key_github_banner_dismissed);
+        return getProfileSharedPreference(context).getBoolean(key, false);
+    }
+
+    public static void setGitHubBannerDismissed(Context context, boolean dismissed) {
+        String key = context.getString(R.string.pref_key_github_banner_dismissed);
+        getProfileSharedPreference(context).edit().putBoolean(key, dismissed).apply();
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
     <string name="pref_key_last_update_check_time" translatable="false">last_update_check_time</string>
     <string name="pref_key_dismissed_update_version" translatable="false">dismissed_update_version</string>
     <string name="pref_key_pending_storage_migration_notice" translatable="false">pending_storage_migration_notice</string>
+    <string name="pref_key_github_banner_dismissed" translatable="false">github_banner_dismissed</string>
     <string name="action_git_profile">Git Profile</string>
     <string name="action_open_in_other_app">Open in other apps</string>
     <string name="action_add_private_key">Add Private Key</string>


### PR DESCRIPTION
Fixes #11

The "Not now" dismissal was stored in `remember { mutableStateOf(false) }`, which is lost whenever the composable leaves composition (navigating into a repo and back, or the Activity being recreated on resume). The banner reappeared every time.

Fix: read/write the dismissal flag via `SharedPreferences` (`Profile.getGitHubBannerDismissed` / `setGitHubBannerDismissed`). The state is now persisted across app resumes and restarts. Once dismissed, the banner won't reappear until the user connects a GitHub account (at which point `isGitHubConnected` is true and it's hidden anyway).