### PR TITLE
feat: add repository pinning

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.getValue
@@ -144,7 +145,12 @@ fun RepoListComposeContent(
         repoOptionsTarget?.let { repo ->
             RepoOptionsDialog(
                 repoName = (repo.getDiaplayName() ?: ""),
+                isPinned = repo.isPinned,
                 onDismissRequest = { repoOptionsTarget = null },
+                onPinClick = {
+                    repoOptionsTarget = null
+                    repo.togglePinned()
+                },
                 onRenameClick = {
                     repoOptionsTarget = null
                     renameTarget = repo
@@ -216,7 +222,9 @@ fun RepoListComposeContent(
 @Composable
 private fun RepoOptionsDialog(
     repoName: String,
+    isPinned: Boolean,
     onDismissRequest: () -> Unit,
+    onPinClick: () -> Unit,
     onRenameClick: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
@@ -226,6 +234,12 @@ private fun RepoOptionsDialog(
         text = {
             val transparentListItemColors = ListItemDefaults.colors(containerColor = Color.Transparent)
             Column {
+                ListItem(
+                    headlineContent = { Text(if (isPinned) "Unpin" else "Pin") },
+                    leadingContent = { Icon(Icons.Default.PushPin, contentDescription = null) },
+                    colors = transparentListItemColors,
+                    modifier = Modifier.clickable(onClick = onPinClick)
+                )
                 ListItem(
                     headlineContent = { Text(stringResource(R.string.label_rename)) },
                     leadingContent = { Icon(Icons.Default.Edit, contentDescription = null) },

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
@@ -163,7 +163,7 @@ fun RepoListScreen(
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = 88.dp) // Space for FAB
                     ) {
-                        items(displayedRepoList) { repo ->
+                        items(displayedRepoList, key = { it.getID() }) { repo ->
                             RepoCard(
                                 repo = repo,
                                 onClick = { onRepoClick(repo) },

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListViewModel.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListViewModel.kt
@@ -14,7 +14,6 @@ import me.sheimi.sgit.BuildConfig
 import me.sheimi.sgit.database.RepoContract
 import me.sheimi.sgit.database.RepoDbManager
 import me.sheimi.sgit.database.models.Repo
-import java.util.Collections
 
 class RepoListViewModel(application: Application) : AndroidViewModel(application), RepoDbManager.RepoDbObserver {
 
@@ -58,7 +57,7 @@ class RepoListViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch {
             val cursor = RepoDbManager.queryAllRepo()
             val repos = Repo.getRepoList(getApplication(), cursor)
-            Collections.sort(repos)
+            repos.sortWith(compareByDescending<Repo> { it.isPinned() }.thenByDescending { it.getID() })
             cursor.close()
             _repoList.value = repos
         }

--- a/app/src/main/java/com/manichord/mgit/ui/components/RepoCard.kt
+++ b/app/src/main/java/com/manichord/mgit/ui/components/RepoCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Label
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -74,6 +75,16 @@ fun RepoCard(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
+                }
+
+                if (repo.isPinned) {
+                    Icon(
+                        imageVector = Icons.Default.PushPin,
+                        contentDescription = "Pinned",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
                 }
 
                 if (isProcessing) {

--- a/app/src/main/java/me/sheimi/sgit/database/RepoContract.java
+++ b/app/src/main/java/me/sheimi/sgit/database/RepoContract.java
@@ -32,12 +32,14 @@ public final class RepoContract {
         public static final String COLUMN_NAME_LATEST_COMMITTER_EMAIL = "latest_committer_email";
         public static final String COLUMN_NAME_LATEST_COMMIT_DATE = "latest_commit_date";
         public static final String COLUMN_NAME_LATEST_COMMIT_MSG = "latest_commit_msg";
+        public static final String COLUMN_NAME_PINNED = "pinned";
         public static final String[] ALL_COLUMNS = { _ID,
                 COLUMN_NAME_LOCAL_PATH, COLUMN_NAME_REMOTE_URL,
                 COLUMN_NAME_REPO_STATUS, COLUMN_NAME_LATEST_COMMITTER_UNAME,
                 COLUMN_NAME_LATEST_COMMITTER_EMAIL,
                 COLUMN_NAME_LATEST_COMMIT_DATE, COLUMN_NAME_LATEST_COMMIT_MSG,
-                COLUMN_NAME_USERNAME, COLUMN_NAME_PASSWORD };
+                COLUMN_NAME_USERNAME, COLUMN_NAME_PASSWORD,
+                COLUMN_NAME_PINNED };
     }
 
     public static final String REPO_ENTRY_CREATE = "CREATE TABLE "
@@ -52,6 +54,7 @@ public final class RepoContract {
             + RepoEntry.COLUMN_NAME_LATEST_COMMITTER_EMAIL + TEXT_TYPE
             + COMMA_SEP + RepoEntry.COLUMN_NAME_LATEST_COMMIT_DATE + TEXT_TYPE
             + COMMA_SEP + RepoEntry.COLUMN_NAME_LATEST_COMMIT_MSG + TEXT_TYPE
+            + COMMA_SEP + RepoEntry.COLUMN_NAME_PINNED + INT_TYPE + "DEFAULT 0"
             + " )";
 
     public static final String REPO_ENTRY_DROP = "DROP TABLE IF EXISTS "
@@ -100,6 +103,10 @@ public final class RepoContract {
 
     public static String getPassword(Cursor cursor) {
         return cursor.getString(9);
+    }
+
+    public static boolean getPinned(Cursor cursor) {
+        return cursor.getInt(10) != 0;
     }
 
 }

--- a/app/src/main/java/me/sheimi/sgit/database/RepoDbHelper.java
+++ b/app/src/main/java/me/sheimi/sgit/database/RepoDbHelper.java
@@ -11,7 +11,7 @@ import java.text.StringCharacterIterator;
  */
 public class RepoDbHelper extends SQLiteOpenHelper {
 
-    private static final int DATABASE_VERSION = 1;
+    private static final int DATABASE_VERSION = 2;
     private static final String DATABASE_NAME = "repo.db";
 
     public RepoDbHelper(Context context) {
@@ -24,9 +24,12 @@ public class RepoDbHelper extends SQLiteOpenHelper {
     }
 
     @Override
-    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i2) {
-        sqLiteDatabase.execSQL(RepoContract.REPO_ENTRY_DROP);
-        onCreate(sqLiteDatabase);
+    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion) {
+        if (oldVersion < 2) {
+            sqLiteDatabase.execSQL("ALTER TABLE " + RepoContract.RepoEntry.TABLE_NAME
+                    + " ADD COLUMN " + RepoContract.RepoEntry.COLUMN_NAME_PINNED
+                    + " INTEGER DEFAULT 0");
+        }
     }
 
     public static String addSlashes(String text) {

--- a/app/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/app/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -45,7 +45,7 @@ public class Repo implements Comparable<Repo>, Serializable {
     /**
      * Generated serialVersionID
      */
-    private static final long serialVersionUID = -4921633809823078219L;
+    private static final long serialVersionUID = -4921633809823078220L;
 
     public static final String TAG = Repo.class.getSimpleName();
 
@@ -65,6 +65,7 @@ public class Repo implements Comparable<Repo>, Serializable {
     private String mLastCommitterEmail;
     private Date mLastCommitDate;
     private String mLastCommitMsg;
+    private boolean mPinned;
     private boolean isDeleted = false;
 
     // lazy load
@@ -89,6 +90,7 @@ public class Repo implements Comparable<Repo>, Serializable {
         mLastCommitterEmail = RepoContract.getLatestCommitterEmail(cursor);
         mLastCommitDate = RepoContract.getLatestCommitDate(cursor);
         mLastCommitMsg = RepoContract.getLatestCommitMsg(cursor);
+        mPinned = RepoContract.getPinned(cursor);
     }
 
     public Bundle getBundle() {
@@ -241,6 +243,7 @@ public class Repo implements Comparable<Repo>, Serializable {
         out.writeObject(mLastCommitterEmail);
         out.writeObject(mLastCommitDate);
         out.writeObject(mLastCommitMsg);
+        out.writeBoolean(mPinned);
     }
 
     private void readObject(java.io.ObjectInputStream in) throws IOException,
@@ -255,6 +258,18 @@ public class Repo implements Comparable<Repo>, Serializable {
         mLastCommitterEmail = (String) in.readObject();
         mLastCommitDate = (Date) in.readObject();
         mLastCommitMsg = (String) in.readObject();
+        mPinned = in.readBoolean();
+    }
+
+    public boolean isPinned() {
+        return mPinned;
+    }
+
+    public void togglePinned() {
+        mPinned = !mPinned;
+        ContentValues values = new ContentValues();
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_PINNED, mPinned ? 1 : 0);
+        RepoDbManager.updateRepo(mID, values);
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Long-press any repo and tap **Pin** to lock it at the top of the list
- Tap **Unpin** on an already-pinned repo to release it
- Pinned repos show a pushpin icon on their card
- Backed by a new `pinned` column with a proper `ALTER TABLE` migration (DB v1 → v2) — no data loss for existing installs

## Screenshots

| Pin dialog | Pinned list | Unpin dialog |
|---|---|---|
| <img width="1080" height="2400" alt="pin_dialog" src="https://github.com/user-attachments/assets/a36d3f72-c0c4-40b6-ab49-a41377327b76" /> | <img width="1080" height="2400" alt="pinned_list" src="https://github.com/user-attachments/assets/1cc7add5-c000-4523-a322-cce6c85239f7" /> |  <img width="1080" height="2400" alt="unpin_dialog" src="https://github.com/user-attachments/assets/fbbda231-9ac7-48c5-95ea-6424037ff844" /> |


## Test plan

- [x] Long-press a repo — Pin option appears in dialog
- [x] Tapping Pin moves repo to top of list immediately with pushpin icon
- [x] Long-pressing a pinned repo shows Unpin instead
- [x] Tapping Unpin returns repo to its natural sort position
- [x] Pin state persists across app restarts (DB-backed)
- [x] Existing installs upgrade cleanly via ALTER TABLE (no drop/recreate)

Closes #17