### PR TITLE
feat: repo labels for filtering

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
@@ -5,11 +5,16 @@ import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Label
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.setValue
@@ -61,6 +66,13 @@ fun RepoListComposeContent(
         var repoOptionsTarget by remember { mutableStateOf<Repo?>(null) }
         var renameTarget by remember { mutableStateOf<Repo?>(null) }
         var deleteTarget by remember { mutableStateOf<Repo?>(null) }
+        var tagsTarget by remember { mutableStateOf<Repo?>(null) }
+
+        val allTags: List<String> = remember(repoListSnapshot) {
+            repoListSnapshot.flatMap { repo: Repo ->
+                repo.labels.filterIsInstance<String>()
+            }.distinct().sorted()
+        }
 
         val context = LocalContext.current
         var githubBannerDismissed by rememberSaveable {
@@ -151,6 +163,10 @@ fun RepoListComposeContent(
                     repoOptionsTarget = null
                     repo.togglePinned()
                 },
+                onTagsClick = {
+                    repoOptionsTarget = null
+                    tagsTarget = repo
+                },
                 onRenameClick = {
                     repoOptionsTarget = null
                     renameTarget = repo
@@ -158,6 +174,18 @@ fun RepoListComposeContent(
                 onDeleteClick = {
                     repoOptionsTarget = null
                     deleteTarget = repo
+                }
+            )
+        }
+
+        tagsTarget?.let { repo ->
+            TagEditorDialog(
+                repo = repo,
+                allTags = allTags,
+                onDismissRequest = { tagsTarget = null },
+                onConfirm = { newTags ->
+                    tagsTarget = null
+                    repo.setLabels(newTags)
                 }
             )
         }
@@ -225,6 +253,7 @@ private fun RepoOptionsDialog(
     isPinned: Boolean,
     onDismissRequest: () -> Unit,
     onPinClick: () -> Unit,
+    onTagsClick: () -> Unit,
     onRenameClick: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
@@ -241,6 +270,12 @@ private fun RepoOptionsDialog(
                     modifier = Modifier.clickable(onClick = onPinClick)
                 )
                 ListItem(
+                    headlineContent = { Text("Tags") },
+                    leadingContent = { Icon(Icons.Default.Label, contentDescription = null) },
+                    colors = transparentListItemColors,
+                    modifier = Modifier.clickable(onClick = onTagsClick)
+                )
+                ListItem(
                     headlineContent = { Text(stringResource(R.string.label_rename)) },
                     leadingContent = { Icon(Icons.Default.Edit, contentDescription = null) },
                     colors = transparentListItemColors,
@@ -255,6 +290,77 @@ private fun RepoOptionsDialog(
             }
         },
         confirmButton = {
+            TextButton(onClick = onDismissRequest) { Text(stringResource(R.string.label_cancel)) }
+        }
+    )
+}
+
+@Composable
+private fun TagEditorDialog(
+    repo: Repo,
+    allTags: List<String>,
+    onDismissRequest: () -> Unit,
+    onConfirm: (Set<String>) -> Unit
+) {
+    var selected by remember { mutableStateOf<Set<String>>(HashSet<String>(repo.labels)) }
+    var newTagText by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Tags") },
+        text = {
+            val displayedTags = remember(allTags, selected) {
+                (allTags + selected.toList()).distinct().sorted()
+            }
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                displayedTags.forEach { tag ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                selected = if (selected.contains(tag)) selected - tag else selected + tag
+                            }
+                    ) {
+                        Checkbox(
+                            checked = selected.contains(tag),
+                            onCheckedChange = { checked ->
+                                selected = if (checked) selected + tag else selected - tag
+                            }
+                        )
+                        Text(tag, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value = newTagText,
+                        onValueChange = { newTagText = it },
+                        placeholder = { Text("New tag") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true
+                    )
+                    IconButton(
+                        onClick = {
+                            val tag = newTagText.trim().lowercase()
+                            if (tag.isNotEmpty()) {
+                                selected = selected + tag
+                                newTagText = ""
+                            }
+                        },
+                        enabled = newTagText.isNotBlank()
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = "Add tag")
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selected) }) { Text("OK") }
+        },
+        dismissButton = {
             TextButton(onClick = onDismissRequest) { Text(stringResource(R.string.label_cancel)) }
         }
     )

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
@@ -2,6 +2,7 @@ package com.manichord.mgit.repolist
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -56,10 +57,22 @@ fun RepoListScreen(
 ) {
     var isSearchActive by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
+    var selectedTag by remember { mutableStateOf<String?>(null) }
     val searchFocusRequester = remember { FocusRequester() }
 
-    val displayedRepoList = remember(repoList, searchQuery) {
-        if (searchQuery.isBlank()) repoList else repoList.filter { it.matchesSearch(searchQuery) }
+    val allTags: List<String> = remember(repoList) {
+        repoList.flatMap { repo: me.sheimi.sgit.database.models.Repo ->
+            repo.labels.filterIsInstance<String>()
+        }.distinct().sorted()
+    }
+
+    // If the selected tag was removed, fall back to "All" without mutating state during composition
+    val effectiveTag: String? = if (selectedTag != null && allTags.contains(selectedTag)) selectedTag else null
+
+    val displayedRepoList = remember(repoList, searchQuery, selectedTag) {
+        repoList
+            .filter { effectiveTag == null || it.hasLabel(effectiveTag) }
+            .filter { searchQuery.isBlank() || it.matchesSearch(searchQuery) }
     }
 
     Scaffold(
@@ -148,6 +161,27 @@ fun RepoListScreen(
                     onConnectClick = onConnectGitHubClick,
                     onDismissClick = onDismissGitHubBanner
                 )
+            }
+            if (allTags.isNotEmpty()) {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    item {
+                        FilterChip(
+                            selected = effectiveTag == null,
+                            onClick = { selectedTag = null },
+                            label = { Text("All") }
+                        )
+                    }
+                    items(allTags, key = { it }) { tag ->
+                        FilterChip(
+                            selected = effectiveTag == tag,
+                            onClick = { selectedTag = if (effectiveTag == tag) null else tag },
+                            label = { Text(tag) }
+                        )
+                    }
+                }
             }
             Box(modifier = Modifier.fillMaxSize()) {
                 if (repoList.isEmpty()) {

--- a/app/src/main/java/me/sheimi/sgit/database/RepoContract.java
+++ b/app/src/main/java/me/sheimi/sgit/database/RepoContract.java
@@ -33,13 +33,14 @@ public final class RepoContract {
         public static final String COLUMN_NAME_LATEST_COMMIT_DATE = "latest_commit_date";
         public static final String COLUMN_NAME_LATEST_COMMIT_MSG = "latest_commit_msg";
         public static final String COLUMN_NAME_PINNED = "pinned";
+        public static final String COLUMN_NAME_TAGS = "tags";
         public static final String[] ALL_COLUMNS = { _ID,
                 COLUMN_NAME_LOCAL_PATH, COLUMN_NAME_REMOTE_URL,
                 COLUMN_NAME_REPO_STATUS, COLUMN_NAME_LATEST_COMMITTER_UNAME,
                 COLUMN_NAME_LATEST_COMMITTER_EMAIL,
                 COLUMN_NAME_LATEST_COMMIT_DATE, COLUMN_NAME_LATEST_COMMIT_MSG,
                 COLUMN_NAME_USERNAME, COLUMN_NAME_PASSWORD,
-                COLUMN_NAME_PINNED };
+                COLUMN_NAME_PINNED, COLUMN_NAME_TAGS };
     }
 
     public static final String REPO_ENTRY_CREATE = "CREATE TABLE "
@@ -55,6 +56,7 @@ public final class RepoContract {
             + COMMA_SEP + RepoEntry.COLUMN_NAME_LATEST_COMMIT_DATE + TEXT_TYPE
             + COMMA_SEP + RepoEntry.COLUMN_NAME_LATEST_COMMIT_MSG + TEXT_TYPE
             + COMMA_SEP + RepoEntry.COLUMN_NAME_PINNED + INT_TYPE + "DEFAULT 0"
+            + COMMA_SEP + RepoEntry.COLUMN_NAME_TAGS + TEXT_TYPE + "DEFAULT ''"
             + " )";
 
     public static final String REPO_ENTRY_DROP = "DROP TABLE IF EXISTS "
@@ -107,6 +109,11 @@ public final class RepoContract {
 
     public static boolean getPinned(Cursor cursor) {
         return cursor.getInt(10) != 0;
+    }
+
+    public static String getTags(Cursor cursor) {
+        String raw = cursor.getString(11);
+        return raw != null ? raw : "";
     }
 
 }

--- a/app/src/main/java/me/sheimi/sgit/database/RepoDbHelper.java
+++ b/app/src/main/java/me/sheimi/sgit/database/RepoDbHelper.java
@@ -11,7 +11,7 @@ import java.text.StringCharacterIterator;
  */
 public class RepoDbHelper extends SQLiteOpenHelper {
 
-    private static final int DATABASE_VERSION = 2;
+    private static final int DATABASE_VERSION = 3;
     private static final String DATABASE_NAME = "repo.db";
 
     public RepoDbHelper(Context context) {
@@ -29,6 +29,11 @@ public class RepoDbHelper extends SQLiteOpenHelper {
             sqLiteDatabase.execSQL("ALTER TABLE " + RepoContract.RepoEntry.TABLE_NAME
                     + " ADD COLUMN " + RepoContract.RepoEntry.COLUMN_NAME_PINNED
                     + " INTEGER DEFAULT 0");
+        }
+        if (oldVersion < 3) {
+            sqLiteDatabase.execSQL("ALTER TABLE " + RepoContract.RepoEntry.TABLE_NAME
+                    + " ADD COLUMN " + RepoContract.RepoEntry.COLUMN_NAME_TAGS
+                    + " TEXT DEFAULT ''");
         }
     }
 

--- a/app/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/app/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -45,7 +46,7 @@ public class Repo implements Comparable<Repo>, Serializable {
     /**
      * Generated serialVersionID
      */
-    private static final long serialVersionUID = -4921633809823078220L;
+    private static final long serialVersionUID = -4921633809823078221L;
 
     public static final String TAG = Repo.class.getSimpleName();
 
@@ -66,6 +67,7 @@ public class Repo implements Comparable<Repo>, Serializable {
     private Date mLastCommitDate;
     private String mLastCommitMsg;
     private boolean mPinned;
+    private Set<String> mTags;
     private boolean isDeleted = false;
 
     // lazy load
@@ -91,6 +93,21 @@ public class Repo implements Comparable<Repo>, Serializable {
         mLastCommitDate = RepoContract.getLatestCommitDate(cursor);
         mLastCommitMsg = RepoContract.getLatestCommitMsg(cursor);
         mPinned = RepoContract.getPinned(cursor);
+        mTags = parseTags(RepoContract.getTags(cursor));
+    }
+
+    private static Set<String> parseTags(String raw) {
+        Set<String> tags = new LinkedHashSet<>();
+        if (raw == null || raw.isEmpty()) return tags;
+        for (String t : raw.split(",")) {
+            String trimmed = t.trim();
+            if (!trimmed.isEmpty()) tags.add(trimmed);
+        }
+        return tags;
+    }
+
+    private static String serializeTags(Set<String> tags) {
+        return String.join(",", tags);
     }
 
     public Bundle getBundle() {
@@ -244,6 +261,7 @@ public class Repo implements Comparable<Repo>, Serializable {
         out.writeObject(mLastCommitDate);
         out.writeObject(mLastCommitMsg);
         out.writeBoolean(mPinned);
+        out.writeObject(serializeTags(mTags));
     }
 
     private void readObject(java.io.ObjectInputStream in) throws IOException,
@@ -259,6 +277,7 @@ public class Repo implements Comparable<Repo>, Serializable {
         mLastCommitDate = (Date) in.readObject();
         mLastCommitMsg = (String) in.readObject();
         mPinned = in.readBoolean();
+        mTags = parseTags((String) in.readObject());
     }
 
     public boolean isPinned() {
@@ -269,6 +288,21 @@ public class Repo implements Comparable<Repo>, Serializable {
         mPinned = !mPinned;
         ContentValues values = new ContentValues();
         values.put(RepoContract.RepoEntry.COLUMN_NAME_PINNED, mPinned ? 1 : 0);
+        RepoDbManager.updateRepo(mID, values);
+    }
+
+    public Set<String> getLabels() {
+        return mTags;
+    }
+
+    public boolean hasLabel(String label) {
+        return mTags.contains(label);
+    }
+
+    public void setLabels(Set<String> labels) {
+        mTags = new LinkedHashSet<>(labels);
+        ContentValues values = new ContentValues();
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_TAGS, serializeTags(mTags));
         RepoDbManager.updateRepo(mID, values);
     }
 


### PR DESCRIPTION
## Summary

- Long-press a repo → **Tags** to assign freeform labels via a checklist dialog (type a new label and press + to add; existing labels from any repo show as checkboxes)
- A filter-chip row appears above the repo list whenever any labels exist — **All** resets, tapping a chip filters to matching repos
- Labels persist in SQLite via a new `tags` TEXT column (DB v3 migration; existing installs upgraded via `ALTER TABLE`)

## Implementation notes

- `Repo.getLabels()` / `setLabels()` / `hasLabel()` — renamed to avoid a method-signature conflict with the pre-existing `getTags(): String[]` that lists JGit ref tags
- Tag checklist shows the union of all-repo labels and the repo's currently-selected labels, so newly typed tags appear immediately as checked items
- `serialVersionUID` bumped on `Repo` to cover the new `mTags` field in the serialized form

## Test plan

- [x] Assign labels to repos via long-press → Tags
- [x] Verify filter chips appear and filter correctly
- [x] Tap All to see all repos again
- [x] Verify labels persist across app restarts
- [x] Upgrade from DB v2 (pinned only) — ALTER TABLE migration adds tags column without data loss



<img width="1080" height="2400" alt="ss1_list_with_chip" src="https://github.com/user-attachments/assets/8123c73f-c1b9-4ac1-8816-1bcae052c952" />
<img width="1080" height="2400" alt="ss2_tag_editor" src="https://github.com/user-attachments/assets/7e726eb1-e6a4-4593-ba03-47135f44ee1b" />
<img width="1080" height="2400" alt="ss3_filtered" src="https://github.com/user-attachments/assets/abdec868-bae3-495e-9b3b-a405aec0d89c" />