### PR TITLE
feat: git command console tab

### DIFF
--- a/app/src/main/java/com/manichord/mgit/MainActivity.kt
+++ b/app/src/main/java/com/manichord/mgit/MainActivity.kt
@@ -29,6 +29,7 @@ import com.manichord.mgit.clone.CloneViewModel
 import com.manichord.mgit.diff.CommitDiffScreen
 import com.manichord.mgit.dialogs.MessageDialog
 import com.manichord.mgit.explorer.FileExplorerScreen
+import com.manichord.mgit.repodetail.GitConsoleScreen
 import com.manichord.mgit.repodetail.RepoDetailScreen
 import com.manichord.mgit.repodetail.RepoDetailViewModel
 import com.manichord.mgit.repolist.RepoListComposeContent
@@ -238,6 +239,7 @@ class MainActivity : SheimiFragmentActivity() {
                                 filesContent = { FragmentHost(supportFragmentManager, filesFragment) },
                                 commitsContent = { FragmentHost(supportFragmentManager, commitsFragment) },
                                 statusContent = { FragmentHost(supportFragmentManager, statusFragment) },
+                                consoleContent = { GitConsoleScreen(viewModel = host.viewModel, repo = host.repo) },
                                 onFilesSearchQueryChange = { query -> host.searchFiles(query) },
                                 onCommitsSearchQueryChange = { query -> host.searchCommits(query) }
                             )

--- a/app/src/main/java/com/manichord/mgit/repodetail/GitCommandEngine.kt
+++ b/app/src/main/java/com/manichord/mgit/repodetail/GitCommandEngine.kt
@@ -1,0 +1,249 @@
+package com.manichord.mgit.repodetail
+
+import me.sheimi.sgit.database.models.Repo
+import org.eclipse.jgit.api.ListBranchCommand
+import org.eclipse.jgit.diff.DiffFormatter
+import org.eclipse.jgit.diff.RawTextComparator
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.revwalk.RevWalk
+import java.io.ByteArrayOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object GitCommandEngine {
+
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+
+    fun execute(repo: Repo, input: String): String {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) return ""
+        val cmd = trimmed.removePrefix("git ").trim()
+        val parts = tokenize(cmd)
+        if (parts.isEmpty()) return ""
+        return try {
+            val git = repo.getGit()
+            when (parts[0]) {
+                "status" -> runStatus(repo)
+                "log" -> runLog(repo, parts.drop(1))
+                "diff" -> runDiff(repo, parts.drop(1))
+                "branch" -> runBranch(repo, parts.drop(1))
+                "stash" -> runStash(repo, parts.drop(1))
+                "help", "--help", "-h" -> helpText()
+                else -> "unknown command: ${parts[0]}\n\n${helpText()}"
+            }
+        } catch (e: Exception) {
+            "error: ${e.message ?: e.javaClass.simpleName}"
+        }
+    }
+
+    private fun runStatus(repo: Repo): String {
+        val git = repo.getGit()
+        val branchName = git.repository.branch ?: "HEAD"
+        val status = git.status().call()
+
+        val sb = StringBuilder()
+        sb.appendLine("On branch $branchName")
+
+        val staged = status.added + status.changed + status.removed
+        if (staged.isNotEmpty()) {
+            sb.appendLine("\nChanges to be committed:")
+            status.added.sorted().forEach { sb.appendLine("        new file:   $it") }
+            status.changed.sorted().forEach { sb.appendLine("        modified:   $it") }
+            status.removed.sorted().forEach { sb.appendLine("        deleted:    $it") }
+        }
+
+        val unstaged = status.modified + status.missing
+        if (unstaged.isNotEmpty()) {
+            sb.appendLine("\nChanges not staged for commit:")
+            status.modified.sorted().forEach { sb.appendLine("        modified:   $it") }
+            status.missing.sorted().forEach { sb.appendLine("        deleted:    $it") }
+        }
+
+        if (status.untracked.isNotEmpty()) {
+            sb.appendLine("\nUntracked files:")
+            status.untracked.sorted().forEach { sb.appendLine("        $it") }
+        }
+
+        if (staged.isEmpty() && unstaged.isEmpty() && status.untracked.isEmpty()) {
+            sb.append("nothing to commit, working tree clean")
+        }
+        return sb.toString().trimEnd()
+    }
+
+    private fun runLog(repo: Repo, args: List<String>): String {
+        val git = repo.getGit()
+        val oneline = "--oneline" in args
+        val graph = "--graph" in args
+        val limit = args.firstOrNull { it.startsWith("-") && it.drop(1).all(Char::isDigit) }
+            ?.drop(1)?.toIntOrNull()
+            ?: args.indexOf("-n").takeIf { it >= 0 }?.let { args.getOrNull(it + 1)?.toIntOrNull() }
+            ?: 20
+        val since = args.firstOrNull { it.startsWith("--since=") }
+            ?.removePrefix("--since=")?.let { parseSinceDate(it) }
+
+        val logCmd = git.log().setMaxCount(if (since != null) 500 else limit)
+        val commits = logCmd.call().toList()
+
+        val filtered = if (since != null) {
+            commits.filter { it.commitTime.toLong() * 1000 >= since }.take(limit)
+        } else commits
+
+        if (filtered.isEmpty()) return "(no commits)"
+
+        val sb = StringBuilder()
+        val prefix = if (graph) "* " else ""
+        filtered.forEach { commit ->
+            val sha = commit.name.take(7)
+            val date = dateFormat.format(Date(commit.commitTime.toLong() * 1000))
+            val author = commit.authorIdent.name
+            val msg = commit.shortMessage
+            if (oneline) {
+                sb.appendLine("$prefix$sha $msg")
+            } else {
+                sb.appendLine("${prefix}commit ${commit.name}")
+                sb.appendLine("Author: $author")
+                sb.appendLine("Date:   $date")
+                sb.appendLine()
+                sb.appendLine("    $msg")
+                sb.appendLine()
+            }
+        }
+        return sb.toString().trimEnd()
+    }
+
+    private fun runDiff(repo: Repo, args: List<String>): String {
+        val git = repo.getGit()
+        val staged = "--staged" in args || "--cached" in args
+        val out = ByteArrayOutputStream()
+        val formatter = DiffFormatter(out).apply {
+            setRepository(git.repository)
+            setDiffComparator(RawTextComparator.DEFAULT)
+            isDetectRenames = true
+        }
+        val diffs = git.diff().setCached(staged).call()
+        if (diffs.isEmpty()) return if (staged) "(no staged changes)" else "(no unstaged changes)"
+
+        val sb = StringBuilder()
+        diffs.take(20).forEach { entry ->
+            sb.appendLine("diff --git a/${entry.oldPath} b/${entry.newPath}")
+            sb.appendLine("--- a/${entry.oldPath}")
+            sb.appendLine("+++ b/${entry.newPath}")
+            try {
+                out.reset()
+                formatter.format(entry)
+                val patch = out.toString()
+                val hunks = patch.lines().filter { it.startsWith("@@") || it.startsWith("+") || it.startsWith("-") }
+                hunks.take(30).forEach { sb.appendLine(it) }
+                if (hunks.size > 30) sb.appendLine("... (${hunks.size - 30} more lines)")
+            } catch (_: Exception) { }
+            sb.appendLine()
+        }
+        if (diffs.size > 20) sb.appendLine("... and ${diffs.size - 20} more file(s)")
+        formatter.close()
+        return sb.toString().trimEnd()
+    }
+
+    private fun runBranch(repo: Repo, args: List<String>): String {
+        val git = repo.getGit()
+        val mode = when {
+            "-a" in args -> ListBranchCommand.ListMode.ALL
+            "-r" in args -> ListBranchCommand.ListMode.REMOTE
+            else -> null
+        }
+        val current = git.repository.branch
+        val branches = git.branchList().apply { mode?.let { setListMode(it) } }.call()
+        if (branches.isEmpty()) return "(no branches)"
+        val sb = StringBuilder()
+        branches.forEach { ref ->
+            val name = ref.name
+                .removePrefix("refs/heads/")
+                .removePrefix("refs/remotes/")
+            val marker = if (ref.name == "refs/heads/$current") "* " else "  "
+            sb.appendLine("$marker$name")
+        }
+        return sb.toString().trimEnd()
+    }
+
+    private fun runStash(repo: Repo, args: List<String>): String {
+        val git = repo.getGit()
+        val sub = args.firstOrNull() ?: "list"
+        return when (sub) {
+            "list" -> {
+                val stashes = git.stashList().call()
+                if (stashes.isEmpty()) return "(no stashes)"
+                stashes.mapIndexed { i, c -> "stash@{$i}: ${c.shortMessage}" }.joinToString("\n")
+            }
+            "save", "push", "" -> {
+                val ref = git.stashCreate().call()
+                if (ref == null) "nothing to stash" else "Saved working directory and index state\n${ref.name.take(7)}"
+            }
+            "pop" -> {
+                val stashes = git.stashList().call().toList()
+                if (stashes.isEmpty()) return "No stash entries found"
+                git.stashApply().setStashRef("stash@{0}").call()
+                git.stashDrop().setStashRef(0).call()
+                "Applied and dropped stash@{0}: ${stashes[0].shortMessage}"
+            }
+            "drop" -> {
+                val index = args.getOrNull(1)?.removePrefix("stash@{")?.removeSuffix("}")?.toIntOrNull() ?: 0
+                val stashes = git.stashList().call().toList()
+                if (index >= stashes.size) return "No stash entry at index $index"
+                git.stashDrop().setStashRef(index).call()
+                "Dropped stash@{$index}: ${stashes[index].shortMessage}"
+            }
+            else -> "unknown stash subcommand: $sub\nUsage: stash [list|push|pop|drop [stash@{n}]]"
+        }
+    }
+
+    private fun helpText() = """
+supported commands:
+  status              show working tree status
+  log                 show commit history
+    --oneline         compact one-line format
+    --graph           with branch graph prefix
+    -n <N> or -<N>    limit number of commits (default 20)
+    --since=<date>    e.g. --since=yesterday, --since=2025-01-01
+  diff                show unstaged changes
+    --staged          show staged changes
+  branch              list local branches
+    -a                list all branches (local + remote)
+    -r                list remote branches only
+  stash               stash / list / pop / drop
+    list              list stash entries
+    push              save working tree to stash
+    pop               apply and drop stash@{0}
+    drop [stash@{n}]  drop a specific stash entry
+  help                show this help
+    """.trimIndent()
+
+    private fun parseSinceDate(since: String): Long? {
+        if (since == "yesterday") {
+            return System.currentTimeMillis() - 86_400_000L
+        }
+        val fmt1 = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val fmt2 = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+        return runCatching { fmt2.parse(since)?.time }
+            .getOrNull()
+            ?: runCatching { fmt1.parse(since)?.time }.getOrNull()
+    }
+
+    private fun tokenize(cmd: String): List<String> {
+        val result = mutableListOf<String>()
+        val current = StringBuilder()
+        var inQuote = false
+        var quoteChar = ' '
+        for (ch in cmd) {
+            when {
+                inQuote && ch == quoteChar -> inQuote = false
+                !inQuote && (ch == '"' || ch == '\'') -> { inQuote = true; quoteChar = ch }
+                !inQuote && ch == ' ' -> {
+                    if (current.isNotEmpty()) { result.add(current.toString()); current.clear() }
+                }
+                else -> current.append(ch)
+            }
+        }
+        if (current.isNotEmpty()) result.add(current.toString())
+        return result
+    }
+}

--- a/app/src/main/java/com/manichord/mgit/repodetail/GitConsoleScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repodetail/GitConsoleScreen.kt
@@ -1,0 +1,209 @@
+package com.manichord.mgit.repodetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.sheimi.sgit.database.models.Repo
+
+private val QUICK_COMMANDS = listOf(
+    "status",
+    "log --oneline -10",
+    "log --oneline --graph -10",
+    "diff",
+    "diff --staged",
+    "branch",
+    "branch -a",
+    "stash list",
+    "stash push",
+    "stash pop",
+)
+
+@Composable
+fun GitConsoleScreen(
+    viewModel: RepoDetailViewModel,
+    repo: Repo,
+    modifier: Modifier = Modifier
+) {
+    val entries by viewModel.consoleEntries.observeAsState(emptyList())
+    val running by viewModel.consoleRunning.observeAsState(false)
+    var inputText by remember { mutableStateOf("") }
+    val commandHistory = remember { mutableStateListOf<String>() }
+    var historyIndex by remember { mutableIntStateOf(-1) }
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(entries.size) {
+        if (entries.isNotEmpty()) listState.animateScrollToItem(entries.size - 1)
+    }
+
+    fun submit(cmd: String) {
+        val trimmed = cmd.trim()
+        if (trimmed.isEmpty()) return
+        if (commandHistory.isEmpty() || commandHistory.last() != trimmed) {
+            commandHistory.add(trimmed)
+        }
+        historyIndex = -1
+        inputText = ""
+        viewModel.runConsoleCommand(repo, trimmed)
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        // Output area
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            if (entries.isEmpty()) {
+                item {
+                    Text(
+                        text = "Git command console\nType a command below or use the quick-action chips.\nType 'help' to see supported commands.",
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
+            }
+            items(entries) { entry ->
+                ConsoleEntryRow(entry)
+            }
+            if (running) {
+                item {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
+                        Spacer(Modifier.width(8.dp))
+                        Text("running…", fontFamily = FontFamily.Monospace, fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+        }
+
+        HorizontalDivider()
+
+        // Quick-action chips
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            QUICK_COMMANDS.forEach { cmd ->
+                SuggestionChip(
+                    onClick = { submit(cmd) },
+                    label = { Text(cmd, fontSize = 11.sp) },
+                    enabled = !running
+                )
+            }
+        }
+
+        // Input row
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Up/Down history buttons
+            IconButton(
+                onClick = {
+                    if (commandHistory.isEmpty()) return@IconButton
+                    historyIndex = (historyIndex + 1).coerceAtMost(commandHistory.size - 1)
+                    inputText = commandHistory[commandHistory.size - 1 - historyIndex]
+                },
+                modifier = Modifier.size(36.dp),
+                enabled = commandHistory.isNotEmpty()
+            ) {
+                Text("↑", fontSize = 16.sp)
+            }
+            IconButton(
+                onClick = {
+                    if (historyIndex <= 0) { historyIndex = -1; inputText = "" }
+                    else { historyIndex--; inputText = commandHistory[commandHistory.size - 1 - historyIndex] }
+                },
+                modifier = Modifier.size(36.dp),
+                enabled = historyIndex >= 0
+            ) {
+                Text("↓", fontSize = 16.sp)
+            }
+
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = { inputText = it; historyIndex = -1 },
+                modifier = Modifier.weight(1f),
+                placeholder = { Text("git status, log, diff…", fontSize = 13.sp, fontFamily = FontFamily.Monospace) },
+                singleLine = true,
+                textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Monospace, fontSize = 13.sp),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(onSend = { submit(inputText) }),
+                enabled = !running,
+                trailingIcon = {
+                    if (inputText.isNotEmpty()) {
+                        IconButton(onClick = { inputText = "" }) {
+                            Icon(Icons.Default.Clear, contentDescription = "Clear", modifier = Modifier.size(18.dp))
+                        }
+                    }
+                }
+            )
+
+            IconButton(
+                onClick = { submit(inputText) },
+                enabled = inputText.isNotBlank() && !running
+            ) {
+                Icon(Icons.Default.Send, contentDescription = "Run")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConsoleEntryRow(entry: RepoDetailViewModel.ConsoleEntry) {
+    val promptColor = MaterialTheme.colorScheme.primary
+    Column {
+        // Command prompt line
+        Text(
+            text = "$ ${entry.command}",
+            fontFamily = FontFamily.Monospace,
+            fontSize = 13.sp,
+            color = promptColor,
+            modifier = Modifier.fillMaxWidth()
+        )
+        // Output
+        if (entry.output.isNotEmpty()) {
+            Text(
+                text = entry.output,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                lineHeight = 18.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 2.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/manichord/mgit/repodetail/RepoDetailScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repodetail/RepoDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
@@ -30,6 +31,7 @@ import androidx.compose.foundation.rememberScrollState
 private const val TAB_FILES = 0
 private const val TAB_COMMITS = 1
 private const val TAB_STATUS = 2
+private const val TAB_CONSOLE = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,6 +43,7 @@ fun RepoDetailScreen(
     filesContent: @Composable () -> Unit,
     commitsContent: @Composable () -> Unit,
     statusContent: @Composable () -> Unit,
+    consoleContent: @Composable () -> Unit = {},
     onFilesSearchQueryChange: (String) -> Unit = {},
     onCommitsSearchQueryChange: (String) -> Unit = {}
 ) {
@@ -62,7 +65,8 @@ fun RepoDetailScreen(
     val tabs = listOf(
         TabItem(stringResource(R.string.tab_files_label), Icons.Default.FolderCopy),
         TabItem(stringResource(R.string.tab_commits_label), Icons.Default.History),
-        TabItem(stringResource(R.string.tab_status_label), Icons.Default.Assessment)
+        TabItem(stringResource(R.string.tab_status_label), Icons.Default.Assessment),
+        TabItem(stringResource(R.string.tab_console_label), Icons.Outlined.Terminal)
     )
 
     val pagerState = rememberPagerState(pageCount = { tabs.size })
@@ -193,6 +197,11 @@ fun RepoDetailScreen(
                                     Icon(Icons.Default.Search, contentDescription = "Search")
                                 }
                             }
+                            if (pagerState.currentPage == TAB_CONSOLE) {
+                                IconButton(onClick = { viewModel.clearConsole() }) {
+                                    Icon(Icons.Default.Clear, contentDescription = "Clear console")
+                                }
+                            }
                             IconButton(onClick = { viewModel.setDrawerOpen(true) }) {
                                 Icon(Icons.Default.Menu, contentDescription = "Menu")
                             }
@@ -228,6 +237,7 @@ fun RepoDetailScreen(
                             0 -> filesContent()
                             1 -> commitsContent()
                             2 -> statusContent()
+                            3 -> consoleContent()
                         }
                     }
 

--- a/app/src/main/java/com/manichord/mgit/repodetail/RepoDetailViewModel.kt
+++ b/app/src/main/java/com/manichord/mgit/repodetail/RepoDetailViewModel.kt
@@ -3,6 +3,10 @@ package com.manichord.mgit.repodetail
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.sheimi.sgit.database.models.Repo
 
 class RepoDetailViewModel : ViewModel() {
@@ -46,5 +50,31 @@ class RepoDetailViewModel : ViewModel() {
 
     fun hideProgress() {
         _progressState.value = _progressState.value?.copy(visible = false)
+    }
+
+    // Console state
+    data class ConsoleEntry(val command: String, val output: String)
+
+    private val _consoleEntries = MutableLiveData<List<ConsoleEntry>>(emptyList())
+    val consoleEntries: LiveData<List<ConsoleEntry>> = _consoleEntries
+
+    private val _consoleRunning = MutableLiveData(false)
+    val consoleRunning: LiveData<Boolean> = _consoleRunning
+
+    fun runConsoleCommand(repo: Repo, command: String) {
+        if (_consoleRunning.value == true) return
+        _consoleRunning.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            val output = GitCommandEngine.execute(repo, command)
+            withContext(Dispatchers.Main) {
+                val current = _consoleEntries.value.orEmpty()
+                _consoleEntries.value = current + ConsoleEntry(command, output)
+                _consoleRunning.value = false
+            }
+        }
+    }
+
+    fun clearConsole() {
+        _consoleEntries.value = emptyList()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="tab_file_label">File</string>
     <string name="tab_commits_label">Commits</string>
     <string name="tab_status_label">Status</string>
+    <string name="tab_console_label">Console</string>
 
     <!-- Dialog Msg -->
     <string name="dialog_choose_branch_title">Choose Branch</string>


### PR DESCRIPTION
## Summary

- Adds a **Console** tab (4th tab, terminal icon) to every repo's detail view
- Commands dispatch to JGit — no shell binary needed on Android
- Session history accumulates across commands; scrolls to latest automatically

## Supported commands

| Command | Notes |
|---|---|
| `branch` | `-a` for all, `-r` for remotes |
| `diff` | `--staged` for staged changes |
| `help` | Lists all supported commands |
| `log` | `--oneline`, `--graph`, `-n <N>`, `--since=<date>` |
| `stash` | `list`, `push`, `pop`, `drop [stash@{n}]` |
| `status` | Shows staged, unstaged, and untracked files |

## UI

- Monospace output; command prompt in theme primary color, output in default color
- Scrollable quick-action chips for the most common commands
- ↑ / ↓ buttons to cycle through command history
- × button in the top bar to clear the session
- Unsupported commands return a helpful error with the supported list

Closes #17 (Built-in Git Command Execution).

## Screenshots

| Screen 1 | Screen 2 | Screen 3 | Screen 4 |
|---|---|---|---|
| <img width="1080" height="2400" alt="screen30" src="https://github.com/user-attachments/assets/d6de1bb6-2a66-4f50-875a-c377fca35d23" /> | <img width="1080" height="2400" alt="screen31" src="https://github.com/user-attachments/assets/214e544d-f1f1-4387-891f-1e3ad168970e" /> | <img width="1080" height="2400" alt="screen32" src="https://github.com/user-attachments/assets/57b57f1a-4bc9-43fb-b426-0666769be1fe" /> | <img width="1080" height="2400" alt="screen33" src="https://github.com/user-attachments/assets/9b58182b-36e6-455a-b7bc-af68f2983387" /> |