### PR TITLE
Redesign home screen widget — clean repo list with branch, status, and commit message

### DIFF
--- a/app/src/main/java/com/manichord/mgit/widget/RepoListWidget.kt
+++ b/app/src/main/java/com/manichord/mgit/widget/RepoListWidget.kt
@@ -13,8 +13,10 @@ import timber.log.Timber
 data class RepoWidgetEntry(
     val id: Int,
     val displayName: String,
+    val branchName: String?,
     val lastCommitMsg: String?,
-    val isDirty: Boolean
+    val isDirty: Boolean,
+    val isPinned: Boolean
 )
 
 class RepoListWidget : GlanceAppWidget() {
@@ -27,9 +29,6 @@ class RepoListWidget : GlanceAppWidget() {
     }
 
     companion object {
-        // Dirty/clean is computed from local .git state only (same call StatusFragment already
-        // uses) -- no network round-trip, safe to run on whatever triggers this (periodic system
-        // update or a manual refresh tap).
         suspend fun loadRepoEntries(context: Context): List<RepoWidgetEntry> = withContext(Dispatchers.IO) {
             val repos = Repo.getRepoList(context, RepoDbManager.queryAllRepo())
             repos.map { repo ->
@@ -40,13 +39,16 @@ class RepoListWidget : GlanceAppWidget() {
                     Timber.w(e, "Widget: failed to read status for %s", repo.getDiaplayName())
                     false
                 }
+                val branch = try { repo.getBranchName().removePrefix("refs/heads/") } catch (_: Exception) { null }
                 RepoWidgetEntry(
                     id = repo.getID(),
-                    displayName = repo.getDiaplayName() ?: "Unknown repository",
+                    displayName = repo.getDiaplayName() ?: "Unknown",
+                    branchName = branch,
                     lastCommitMsg = repo.getLastCommitMsg(),
-                    isDirty = isDirty
+                    isDirty = isDirty,
+                    isPinned = repo.isPinned
                 )
-            }
+            }.sortedWith(compareByDescending<RepoWidgetEntry> { it.isPinned }.thenBy { it.displayName })
         }
     }
 }

--- a/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
+++ b/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
@@ -1,12 +1,13 @@
 package com.manichord.mgit.widget
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.lazy.items
 import androidx.glance.background
@@ -15,47 +16,79 @@ import androidx.glance.layout.Box
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxHeight
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.glance.GlanceComposable
+import androidx.compose.runtime.Composable
 
 @Composable
+@GlanceComposable
 fun RepoWidgetContent(repos: List<RepoWidgetEntry>) {
     GlanceTheme {
         Column(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .background(GlanceTheme.colors.surface)
-                .padding(8.dp)
+                .background(GlanceTheme.colors.widgetBackground)
+                .padding(horizontal = 14.dp, vertical = 12.dp)
         ) {
+            // Compact header
             Row(
                 modifier = GlanceModifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Vertical.CenterVertically
             ) {
                 Text(
-                    text = "Gitling",
-                    style = TextStyle(color = GlanceTheme.colors.onSurface, fontWeight = FontWeight.Bold),
+                    text = "GITLING",
+                    style = TextStyle(
+                        color = GlanceTheme.colors.primary,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 10.sp
+                    ),
                     modifier = GlanceModifier.defaultWeight()
                 )
                 Text(
-                    text = "⟳", // refresh glyph -- no icon asset needed for a single tap target
-                    style = TextStyle(color = GlanceTheme.colors.primary, fontWeight = FontWeight.Bold),
+                    text = "↻",
+                    style = TextStyle(
+                        color = GlanceTheme.colors.secondary,
+                        fontSize = 16.sp
+                    ),
                     modifier = GlanceModifier
-                        .padding(4.dp)
+                        .padding(start = 8.dp)
                         .clickable(actionRunCallback<RefreshWidgetAction>())
                 )
             }
-            Spacer(modifier = GlanceModifier.size(4.dp))
+
+            // Divider under header
+            Spacer(modifier = GlanceModifier.height(5.dp))
+            Box(
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(GlanceTheme.colors.onBackground)
+            ) {}
+
+            Spacer(modifier = GlanceModifier.height(4.dp))
+
             if (repos.isEmpty()) {
-                Text(
-                    text = "No repos cloned yet",
-                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant)
-                )
+                Box(
+                    modifier = GlanceModifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "No repos cloned yet",
+                        style = TextStyle(
+                            color = GlanceTheme.colors.secondary,
+                            fontSize = 13.sp
+                        )
+                    )
+                }
             } else {
                 LazyColumn(modifier = GlanceModifier.fillMaxSize()) {
                     items(repos, itemId = { it.id.toLong() }) { repo ->
@@ -68,35 +101,72 @@ fun RepoWidgetContent(repos: List<RepoWidgetEntry>) {
 }
 
 @Composable
+@GlanceComposable
 private fun RepoWidgetRow(repo: RepoWidgetEntry) {
-    Row(
+    Column(
         modifier = GlanceModifier
             .fillMaxWidth()
-            .padding(vertical = 6.dp)
+            .padding(vertical = 7.dp)
             .clickable(
                 actionRunCallback<OpenRepoWidgetAction>(
                     actionParametersOf(RepoIdParamKey to repo.id)
                 )
-            ),
-        verticalAlignment = Alignment.Vertical.CenterVertically
+            )
     ) {
-        Box(
-            modifier = GlanceModifier
-                .size(8.dp)
-                .background(if (repo.isDirty) GlanceTheme.colors.error else GlanceTheme.colors.primary)
-        ) {}
-        Spacer(modifier = GlanceModifier.width(8.dp))
-        Column(modifier = GlanceModifier.defaultWeight()) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Vertical.CenterVertically
+        ) {
+            // Status circle — large enough to see at a glance
+            Box(
+                modifier = GlanceModifier
+                    .size(12.dp)
+                    .cornerRadius(6.dp)
+                    .background(
+                        if (repo.isDirty) GlanceTheme.colors.error
+                        else GlanceTheme.colors.primary
+                    )
+            ) {}
+            Spacer(modifier = GlanceModifier.width(8.dp))
+
+            // Repo name
             Text(
                 text = repo.displayName,
-                style = TextStyle(color = GlanceTheme.colors.onSurface, fontWeight = FontWeight.Medium),
-                maxLines = 1
+                style = TextStyle(
+                    color = GlanceTheme.colors.onBackground,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp
+                ),
+                maxLines = 1,
+                modifier = GlanceModifier.defaultWeight()
             )
-            if (!repo.lastCommitMsg.isNullOrBlank()) {
+
+            // Branch name — right-aligned
+            repo.branchName?.let { branch ->
+                Spacer(modifier = GlanceModifier.width(6.dp))
+                Text(
+                    text = branch,
+                    style = TextStyle(
+                        color = GlanceTheme.colors.secondary,
+                        fontSize = 11.sp
+                    ),
+                    maxLines = 1
+                )
+            }
+        }
+
+        // Last commit message, indented to align under the repo name
+        if (!repo.lastCommitMsg.isNullOrBlank()) {
+            Row(modifier = GlanceModifier.fillMaxWidth()) {
+                Spacer(modifier = GlanceModifier.width(20.dp))
                 Text(
                     text = repo.lastCommitMsg,
-                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant),
-                    maxLines = 1
+                    style = TextStyle(
+                        color = GlanceTheme.colors.secondary,
+                        fontSize = 11.sp
+                    ),
+                    maxLines = 1,
+                    modifier = GlanceModifier.defaultWeight()
                 )
             }
         }

--- a/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
+++ b/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
@@ -39,42 +39,24 @@ fun RepoWidgetContent(repos: List<RepoWidgetEntry>) {
                 .background(GlanceTheme.colors.widgetBackground)
                 .padding(horizontal = 14.dp, vertical = 12.dp)
         ) {
-            // Compact header
+            // Refresh button — top right, no header text
             Row(
                 modifier = GlanceModifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Vertical.CenterVertically
             ) {
-                Text(
-                    text = "GITLING",
-                    style = TextStyle(
-                        color = GlanceTheme.colors.primary,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 10.sp
-                    ),
-                    modifier = GlanceModifier.defaultWeight()
-                )
+                Spacer(modifier = GlanceModifier.defaultWeight())
                 Text(
                     text = "↻",
                     style = TextStyle(
                         color = GlanceTheme.colors.secondary,
-                        fontSize = 16.sp
+                        fontSize = 14.sp
                     ),
                     modifier = GlanceModifier
-                        .padding(start = 8.dp)
                         .clickable(actionRunCallback<RefreshWidgetAction>())
                 )
             }
 
-            // Divider under header
-            Spacer(modifier = GlanceModifier.height(5.dp))
-            Box(
-                modifier = GlanceModifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(GlanceTheme.colors.onBackground)
-            ) {}
-
-            Spacer(modifier = GlanceModifier.height(4.dp))
+            Spacer(modifier = GlanceModifier.height(2.dp))
 
             if (repos.isEmpty()) {
                 Box(

--- a/app/src/main/java/me/sheimi/android/utils/FsUtils.java
+++ b/app/src/main/java/me/sheimi/android/utils/FsUtils.java
@@ -14,7 +14,10 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import android.content.Context;
+
 import me.sheimi.android.activities.SheimiFragmentActivity;
+import me.sheimi.sgit.MGitApplication;
 import me.sheimi.sgit.R;
 
 /**
@@ -91,10 +94,12 @@ public class FsUtils {
      */
     public static File getAppDir(boolean isExternal) {
         SheimiFragmentActivity activeActivity = BasicFunctions.getActiveActivity();
+        // Fall back to Application context when called from a non-Activity context (e.g. widget)
+        Context context = activeActivity != null ? activeActivity : MGitApplication.getContext();
         if (isExternal) {
-            return activeActivity.getExternalFilesDir(null);
+            return context.getExternalFilesDir(null);
         } else {
-            return activeActivity.getFilesDir();
+            return context.getFilesDir();
         }
     }
 
@@ -106,7 +111,9 @@ public class FsUtils {
      * files" granted), without Gitling itself needing to request anything. */
     public static File getMediaDir(String dirname, boolean isCreate) {
         SheimiFragmentActivity activeActivity = BasicFunctions.getActiveActivity();
-        File[] mediaDirs = activeActivity.getExternalMediaDirs();
+        // Fall back to Application context when called from a non-Activity context (e.g. widget)
+        Context context = activeActivity != null ? activeActivity : MGitApplication.getContext();
+        File[] mediaDirs = context.getExternalMediaDirs();
         File mDir = new File(mediaDirs[0], dirname);
         if (!mDir.exists() && isCreate) {
             mDir.mkdirs();


### PR DESCRIPTION
## Summary

- **New layout:** small ↻ refresh button top-right; each repo row shows a status circle (green=clean, red=dirty), bold repo name, branch name right-aligned, and last commit message as a subtitle
- **Sorting:** pinned repos float to the top, rest alphabetical
- **Branch display:** strips `refs/heads/` prefix so "main" shows instead of "refs/heads/main"
- **Bug fix:** `FsUtils.getAppDir()` and `getMediaDir()` crashed with NPE when called without a live Activity (e.g. widget background refresh). Now falls back to `MGitApplication.getContext()` — fixes both dirty-status detection and branch name loading in the widget

## Test plan

- [ ] Add widget to home screen — repos appear with name, branch, and last commit message
- [ ] Pinned repo sorts to top
- [ ] Dirty repo shows red circle (make a local edit, tap ↻ to refresh)
- [ ] Clean repos show green circle
- [ ] Branch shows short form ("main", not "refs/heads/main")
- [ ] Tapping a repo opens it in the app
- [ ] ↻ refresh button reloads data
- [ ] Widget works after app process is killed (no NPE crash from FsUtils)
- [ ] Empty state shows "No repos cloned yet" when repo list is empty