### PR TITLE
fix: restore File tab content after switching away to Blame tab

### DIFF
--- a/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.kt
+++ b/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.kt
@@ -147,7 +147,12 @@ class ViewFileActivity : SheimiFragmentActivity() {
     }
 
     private fun setupWebView(view: WebView) {
-        if (webView != null) return // AndroidView's factory should only run once; guard anyway
+        // Guard on the view instance itself: Compose can re-create the AndroidView node when
+        // switching away from the File tab and back, delivering a new WebView instance while
+        // the Activity-level `webView` field still holds the old (disposed) one. Guarding on
+        // `webView != null` caused the new instance to be skipped entirely, leaving a blank page.
+        if (view.getTag(R.id.tag_webview_initialized) == true) return
+        view.setTag(R.id.tag_webview_initialized, true)
         webView = view
         view.addJavascriptInterface(CodeLoader(), JS_INTERFACE)
         view.settings.javaScriptEnabled = true

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="tag_webview_initialized" type="id"/>
+</resources>


### PR DESCRIPTION
## Summary

- Tapping Blame then returning to File showed a blank page instead of the file content
- Root cause: Compose's tab pager disposes and re-creates the `AndroidView`/WebView node when navigating away and back; the guard `if (webView != null) return` in `setupWebView` still held the old (disposed) instance, so the new WebView was never initialised
- Fix: guard on a tag set directly on the view instance (`view.getTag(R.id.tag_webview_initialized)`) so each new WebView gets fully set up regardless of the Activity-level field

## Test plan

- [ ] Open a repo → tap a file → File tab shows content
- [ ] Tap Blame tab → blame data appears
- [ ] Tap File tab back → file content still visible (was blank before this fix)
- [ ] Repeat the round-trip multiple times — stays consistent