### PR TITLE
feat: support self-hosted Forgejo and other custom git instances

### DIFF
--- a/app/src/main/java/com/manichord/mgit/auth/AccountManager.kt
+++ b/app/src/main/java/com/manichord/mgit/auth/AccountManager.kt
@@ -37,7 +37,8 @@ class AccountManager(private val securePrefsHelper: SecurePrefsHelper) {
                         name = jsonObj.getString("name"),
                         username = jsonObj.getString("username"),
                         token = jsonObj.getString("token"),
-                        type = AccountType.valueOf(jsonObj.getString("type"))
+                        type = AccountType.valueOf(jsonObj.getString("type")),
+                        baseUrl = jsonObj.optString("baseUrl").takeIf { it.isNotBlank() }
                     )
                 )
             }
@@ -70,13 +71,23 @@ class AccountManager(private val securePrefsHelper: SecurePrefsHelper) {
             null
         } ?: return null
 
-        val type = when {
+        val accounts = getAccounts()
+        val knownType = when {
             host.endsWith("github.com") -> AccountType.GITHUB
             host.endsWith("gitlab.com") -> AccountType.GITLAB
             host.endsWith("bitbucket.org") -> AccountType.BITBUCKET
-            else -> return null
+            else -> null
         }
-        return getAccounts().firstOrNull { it.type == type }
+        if (knownType != null) {
+            return accounts.firstOrNull { it.type == knownType }
+        }
+        // For custom/self-hosted instances (e.g. Forgejo, Gitea), match by comparing the
+        // remote's host against the host stored in the account's baseUrl.
+        return accounts.firstOrNull { account ->
+            if (account.baseUrl.isNullOrBlank()) return@firstOrNull false
+            val accountHost = try { java.net.URI(account.baseUrl).host } catch (e: Exception) { null }
+            accountHost != null && host.equals(accountHost, ignoreCase = true)
+        }
     }
 
     fun updateAccount(updatedAccount: Account) {
@@ -96,6 +107,7 @@ class AccountManager(private val securePrefsHelper: SecurePrefsHelper) {
             jsonObj.put("username", account.username)
             jsonObj.put("token", account.token)
             jsonObj.put("type", account.type.name)
+            if (!account.baseUrl.isNullOrBlank()) jsonObj.put("baseUrl", account.baseUrl)
             jsonArray.put(jsonObj)
         }
         securePrefsHelper.set(KEY_ACCOUNTS, jsonArray.toString())

--- a/app/src/main/java/com/manichord/mgit/models/Account.kt
+++ b/app/src/main/java/com/manichord/mgit/models/Account.kt
@@ -12,5 +12,6 @@ data class Account(
     val name: String,
     val username: String,
     val token: String,
-    val type: AccountType = AccountType.GITHUB
+    val type: AccountType = AccountType.GITHUB,
+    val baseUrl: String? = null
 )

--- a/app/src/main/java/com/manichord/mgit/settings/AccountsScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/settings/AccountsScreen.kt
@@ -259,6 +259,7 @@ fun AddAccountDialog(
     var name by remember { mutableStateOf("") }
     var username by remember { mutableStateOf("") }
     var token by remember { mutableStateOf("") }
+    var baseUrl by remember { mutableStateOf("") }
     var type by remember { mutableStateOf(AccountType.GITHUB) }
     var expanded by remember { mutableStateOf(false) }
     var tokenVisible by remember { mutableStateOf(false) }
@@ -312,7 +313,19 @@ fun AddAccountDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                if (type == AccountType.GITHUB || type == AccountType.GITLAB || type == AccountType.BITBUCKET) {
+                if (type == AccountType.CUSTOM) {
+                    OutlinedTextField(
+                        value = baseUrl,
+                        onValueChange = { baseUrl = it },
+                        label = { Text("Instance URL (e.g. https://forgejo.example.com)") },
+                        singleLine = true,
+                        isError = showErrors && baseUrl.isBlank(),
+                        supportingText = if (showErrors && baseUrl.isBlank()) {
+                            { Text("Required for custom instances") }
+                        } else null,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
                     val tokenUrl = when (type) {
                         AccountType.GITHUB -> "https://github.com/settings/tokens/new?scopes=repo,user"
                         AccountType.GITLAB -> "https://gitlab.com/-/user_settings/personal_access_tokens"
@@ -363,10 +376,17 @@ fun AddAccountDialog(
         confirmButton = {
             Button(
                 onClick = {
-                    if (name.isBlank() || username.isBlank() || token.isBlank()) {
+                    val customUrlMissing = type == AccountType.CUSTOM && baseUrl.isBlank()
+                    if (name.isBlank() || username.isBlank() || token.isBlank() || customUrlMissing) {
                         showErrors = true
                     } else {
-                        onConfirm(Account(name = name, username = username, token = token, type = type))
+                        onConfirm(Account(
+                            name = name,
+                            username = username,
+                            token = token,
+                            type = type,
+                            baseUrl = baseUrl.takeIf { type == AccountType.CUSTOM && it.isNotBlank() }
+                        ))
                     }
                 }
             ) {


### PR DESCRIPTION
## Summary

- Added `baseUrl` field to `Account` for custom/self-hosted instances (Forgejo, Gitea, etc.)
- When Account type is **Custom**, the Add Account dialog shows an **Instance URL** field (e.g. `https://forgejo.example.com`) instead of the hosted-service token link
- `AccountManager.findAccountForRemoteUrl()` now matches Custom accounts by comparing the remote URL's host against the stored `baseUrl` — credentials are applied on fetch/pull/clone exactly like GitHub/GitLab/Bitbucket
- JSON serialisation is backwards-compatible: existing accounts without `baseUrl` load fine

## Demo

![Custom account type showing Instance URL field](https://github.com/maneeshacooray/Gitling/releases/download/v1.0.43/custom-account-demo.gif)

*Selecting Custom type shows the Instance URL field; switching back to GitHub/GitLab hides it and restores the "Get a token" link.*

## Test plan

- [ ] Settings → Managed Accounts → Add account → select **Custom** → Instance URL field appears
- [ ] Select GitHub/GitLab/Bitbucket → Instance URL field is hidden, "Get a token" link shown instead
- [ ] Add a Custom account with a base URL — it saves and appears in the list
- [ ] Clone a repo from that host — credentials are applied (no auth prompt)