### PR TITLE
fix: remove automatic update available banner from home screen

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
@@ -1,7 +1,5 @@
 package com.manichord.mgit.repolist
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -48,7 +46,6 @@ fun RepoListComposeContent(
 ) {
     AppTheme {
         val repoListSnapshot by viewModel.repoList.collectAsState()
-        val updateAvailable by viewModel.updateAvailable.collectAsState()
         val showStorageMigrationNotice by viewModel.showStorageMigrationNotice.collectAsState()
         var showCloneSheet by remember { mutableStateOf(false) }
         val sheetState = rememberModalBottomSheetState()
@@ -125,11 +122,6 @@ fun RepoListComposeContent(
             onConnectGitHubClick = {
                 (activity as MainActivity).openUserSettings(initialScreen = "accounts")
             },
-            updateAvailableVersion = updateAvailable?.versionName,
-            onViewReleaseClick = {
-                updateAvailable?.let { activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(it.releaseUrl))) }
-            },
-            onDismissUpdateClick = { viewModel.dismissUpdateAvailable() }
         )
 
         if (showCloneSheet) {

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListScreen.kt
@@ -50,10 +50,7 @@ fun RepoListScreen(
     onRepoLongClick: (Repo) -> Unit,
     onCloneClick: () -> Unit,
     onSettingsClick: () -> Unit,
-    onConnectGitHubClick: () -> Unit,
-    updateAvailableVersion: String? = null,
-    onViewReleaseClick: () -> Unit = {},
-    onDismissUpdateClick: () -> Unit = {}
+    onConnectGitHubClick: () -> Unit
 ) {
     var isSearchActive by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
@@ -149,13 +146,6 @@ fun RepoListScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            if (updateAvailableVersion != null) {
-                UpdateAvailableBanner(
-                    versionName = updateAvailableVersion,
-                    onViewReleaseClick = onViewReleaseClick,
-                    onDismissClick = onDismissUpdateClick
-                )
-            }
             if (!isGitHubConnected && !githubBannerDismissed && repoList.isNotEmpty()) {
                 ConnectGitHubBanner(
                     onConnectClick = onConnectGitHubClick,
@@ -234,45 +224,6 @@ private fun NoSearchResultsView(query: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center
         )
-    }
-}
-
-@Composable
-private fun UpdateAvailableBanner(
-    versionName: String,
-    onViewReleaseClick: () -> Unit,
-    onDismissClick: () -> Unit
-) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp, 8.dp, 16.dp, 0.dp),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.tertiaryContainer
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                "Update available",
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onTertiaryContainer
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                "Version $versionName is available on GitHub",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onTertiaryContainer
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
-            ) {
-                TextButton(onClick = onDismissClick) { Text("Not now") }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(onClick = onViewReleaseClick) { Text("View release") }
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListViewModel.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListViewModel.kt
@@ -3,36 +3,22 @@ package com.manichord.mgit.repolist
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.manichord.mgit.update.UpdateCheckResult
-import com.manichord.mgit.update.UpdateChecker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import me.sheimi.android.utils.Profile
-import me.sheimi.sgit.BuildConfig
 import me.sheimi.sgit.database.RepoContract
 import me.sheimi.sgit.database.RepoDbManager
 import me.sheimi.sgit.database.models.Repo
 
 class RepoListViewModel(application: Application) : AndroidViewModel(application), RepoDbManager.RepoDbObserver {
 
-    companion object {
-        // GitHub's API rate limit for unauthenticated requests is generous (60/hr per IP) but
-        // there's no reason to check more than once a day -- new releases don't ship that often.
-        private const val UPDATE_CHECK_COOLDOWN_MILLIS = 24L * 60 * 60 * 1000
-    }
-
     private val _repoList = MutableStateFlow<List<Repo>>(emptyList())
     val repoList: StateFlow<List<Repo>> = _repoList.asStateFlow()
 
-    private val _updateAvailable = MutableStateFlow<UpdateCheckResult.UpdateAvailable?>(null)
-    val updateAvailable: StateFlow<UpdateCheckResult.UpdateAvailable?> = _updateAvailable.asStateFlow()
-
     private val _showStorageMigrationNotice = MutableStateFlow(false)
     val showStorageMigrationNotice: StateFlow<Boolean> = _showStorageMigrationNotice.asStateFlow()
-
-    private val updateChecker = UpdateChecker()
 
     init {
         // Must run before refreshRepoList() so the first load reflects any converted paths, and
@@ -44,7 +30,6 @@ class RepoListViewModel(application: Application) : AndroidViewModel(application
         }
         RepoDbManager.registerDbObserver(RepoContract.RepoEntry.TABLE_NAME, this)
         refreshRepoList()
-        maybeCheckForUpdate()
         _showStorageMigrationNotice.value = Profile.getPendingStorageMigrationNotice(getApplication())
     }
 
@@ -61,26 +46,6 @@ class RepoListViewModel(application: Application) : AndroidViewModel(application
             cursor.close()
             _repoList.value = repos
         }
-    }
-
-    private fun maybeCheckForUpdate() {
-        val context = getApplication<Application>()
-        val sinceLastCheck = System.currentTimeMillis() - Profile.getLastUpdateCheckTime(context)
-        if (sinceLastCheck < UPDATE_CHECK_COOLDOWN_MILLIS) return
-
-        updateChecker.checkForUpdate(BuildConfig.VERSION_NAME) { result ->
-            Profile.setLastUpdateCheckTime(context, System.currentTimeMillis())
-            if (result is UpdateCheckResult.UpdateAvailable &&
-                result.versionName != Profile.getDismissedUpdateVersion(context)
-            ) {
-                _updateAvailable.value = result
-            }
-        }
-    }
-
-    fun dismissUpdateAvailable() {
-        _updateAvailable.value?.let { Profile.setDismissedUpdateVersion(getApplication(), it.versionName) }
-        _updateAvailable.value = null
     }
 
     override fun nofityChanged() {


### PR DESCRIPTION
## Summary

- Removes the automatic "Update available" banner that appeared on the home screen after detecting a newer release on GitHub
- Removes the background update check that fired on every app launch (`maybeCheckForUpdate()` in `RepoListViewModel`)
- The **Settings → Check for Updates** button is unchanged — users can still check manually

## Changes

- `RepoListViewModel`: removed `updateAvailable` state, `updateChecker` instance, `maybeCheckForUpdate()`, and `dismissUpdateAvailable()`
- `RepoListScreen`: removed `updateAvailableVersion`/`onViewReleaseClick`/`onDismissUpdateClick` params and `UpdateAvailableBanner` composable
- `RepoListComposeIntegration`: removed banner wiring and now-unused `Intent`/`Uri` imports
- `UpdateChecker.kt` is untouched — still used by `SettingsViewModel` for the manual check