### PR TITLE
feat: add Stage All and Unstage All to the Status screen

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repodetail/StatusScreen.kt
+++ b/app/src/main/java/com/manichord/mgit/repodetail/StatusScreen.kt
@@ -61,6 +61,8 @@ fun StatusScreen(
     conflictingFiles: List<String>,
     onStageFile: (String) -> Unit,
     onUnstageFile: (String) -> Unit,
+    onStageAll: () -> Unit,
+    onUnstageAll: () -> Unit,
     onViewStagedDiff: () -> Unit,
     onViewUnstagedDiff: () -> Unit
 ) {
@@ -87,13 +89,27 @@ fun StatusScreen(
                     }
                 }
                 if (stagedFiles.isNotEmpty()) {
-                    item { SectionHeader("Staged Changes", onViewDiff = onViewStagedDiff) }
+                    item {
+                        SectionHeader(
+                            "Staged Changes",
+                            onViewDiff = onViewStagedDiff,
+                            onBulkAction = onUnstageAll,
+                            bulkActionLabel = "Unstage all"
+                        )
+                    }
                     items(stagedFiles, key = { "staged:" + it.path }) { entry ->
                         FileRow(entry, actionIcon = Icons.Default.RemoveCircle, actionDescription = "Unstage", onAction = { onUnstageFile(entry.path) })
                     }
                 }
                 if (unstagedFiles.isNotEmpty()) {
-                    item { SectionHeader("Unstaged Changes", onViewDiff = onViewUnstagedDiff) }
+                    item {
+                        SectionHeader(
+                            "Unstaged Changes",
+                            onViewDiff = onViewUnstagedDiff,
+                            onBulkAction = onStageAll,
+                            bulkActionLabel = "Stage all"
+                        )
+                    }
                     items(unstagedFiles, key = { "unstaged:" + it.path }) { entry ->
                         FileRow(entry, actionIcon = Icons.Default.AddCircle, actionDescription = "Stage", onAction = { onStageFile(entry.path) })
                     }
@@ -104,16 +120,26 @@ fun StatusScreen(
 }
 
 @Composable
-private fun SectionHeader(title: String, onViewDiff: (() -> Unit)? = null) {
+private fun SectionHeader(
+    title: String,
+    onViewDiff: (() -> Unit)? = null,
+    onBulkAction: (() -> Unit)? = null,
+    bulkActionLabel: String? = null
+) {
     Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
-            if (onViewDiff != null) {
-                TextButton(onClick = onViewDiff) { Text("View diff") }
+            Row {
+                if (onBulkAction != null && bulkActionLabel != null) {
+                    TextButton(onClick = onBulkAction) { Text(bulkActionLabel) }
+                }
+                if (onViewDiff != null) {
+                    TextButton(onClick = onViewDiff) { Text("View diff") }
+                }
             }
         }
     }

--- a/app/src/main/java/me/sheimi/sgit/fragments/StatusFragment.kt
+++ b/app/src/main/java/me/sheimi/sgit/fragments/StatusFragment.kt
@@ -18,6 +18,7 @@ import me.sheimi.sgit.database.models.Repo
 import me.sheimi.sgit.repo.tasks.repo.AddToStageTask
 import me.sheimi.sgit.repo.tasks.repo.RemoveFromStageTask
 import me.sheimi.sgit.repo.tasks.repo.StatusTask
+import me.sheimi.sgit.repo.tasks.repo.UnstageAllTask
 import org.eclipse.jgit.api.Status
 
 class StatusFragment : RepoDetailFragment() {
@@ -70,6 +71,8 @@ class StatusFragment : RepoDetailFragment() {
                         conflictingFiles = conflictingFiles,
                         onStageFile = { path -> stageFile(path) },
                         onUnstageFile = { path -> unstageFile(path) },
+                        onStageAll = { stageAll() },
+                        onUnstageAll = { unstageAll() },
                         onViewStagedDiff = { showDiff("HEAD", "dircache") },
                         onViewUnstagedDiff = { showDiff("dircache", "filetree") }
                     )
@@ -92,9 +95,19 @@ class StatusFragment : RepoDetailFragment() {
         AddToStageTask(repo, path) { reset() }.executeTask()
     }
 
+    private fun stageAll() {
+        val repo = repo ?: return
+        AddToStageTask(repo, ".") { reset() }.executeTask()
+    }
+
     private fun unstageFile(path: String) {
         val repo = repo ?: return
         RemoveFromStageTask(repo, path) { reset() }.executeTask()
+    }
+
+    private fun unstageAll() {
+        val repo = repo ?: return
+        UnstageAllTask(repo) { reset() }.executeTask()
     }
 
     override fun reset() {

--- a/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/UnstageAllTask.java
+++ b/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/UnstageAllTask.java
@@ -1,0 +1,39 @@
+package me.sheimi.sgit.repo.tasks.repo;
+
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.exception.StopTaskException;
+import me.sheimi.sgit.repo.tasks.SheimiAsyncTask.AsyncTaskPostCallback;
+
+public class UnstageAllTask extends RepoOpTask {
+
+    private AsyncTaskPostCallback mCallback;
+
+    public UnstageAllTask(Repo repo, AsyncTaskPostCallback callback) {
+        super(repo);
+        mCallback = callback;
+        setSuccessMsg(R.string.success_remove_from_stage);
+    }
+
+    @Override
+    protected Boolean doInBackground(Void... params) {
+        try {
+            // Mixed reset with no paths — equivalent to `git reset HEAD`, unstages everything.
+            mRepo.getGit().reset().call();
+        } catch (StopTaskException e) {
+            return false;
+        } catch (Throwable e) {
+            setException(e);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void onPostExecute(Boolean isSuccess) {
+        super.onPostExecute(isSuccess);
+        if (mCallback != null) {
+            mCallback.onPostExecute(isSuccess);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Added **Stage all** button to the Unstaged Changes section header — stages every unstaged file with one tap (`git add .`)
- Added **Unstage all** button to the Staged Changes section header — unstages everything with one tap (`git reset HEAD`)
- Both buttons sit alongside the existing "View diff" button in the section header
- New `UnstageAllTask` follows the existing `SheimiAsyncTask` pattern

## Demo

![Stage all and Unstage all in action](https://github.com/maneeshacooray/Gitling/releases/download/v1.0.46/stage-all-demo.gif)

## Test plan

- [ ] Status tab with unstaged files → "Stage all" button appears → tap it → all files move to Staged Changes
- [ ] Status tab with staged files → "Unstage all" button appears → tap it → all files move back to Unstaged Changes
- [ ] Individual stage/unstage per-file buttons still work
- [ ] No buttons shown when the relevant section is empty