### PR TITLE
fix(widget): add corner clearance to refresh button

### DIFF
--- a/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
+++ b/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
@@ -45,7 +45,8 @@ fun RepoWidgetContent(repos: List<RepoWidgetEntry>) {
                         CircleIconButton(
                             imageProvider = ImageProvider(R.drawable.ic_sync),
                             contentDescription = "Refresh",
-                            onClick = actionRunCallback<RefreshWidgetAction>()
+                            onClick = actionRunCallback<RefreshWidgetAction>(),
+                            modifier = GlanceModifier.padding(end = 4.dp, top = 4.dp)
                         )
                     }
                 )


### PR DESCRIPTION
## Summary

- The circle refresh button in the home screen widget's title bar sat flush against the top-right rounded corner, with the wallpaper visibly peeking through above it -- unlike the leading logo icon, which has generous clearance from the top-left corner.
- Adds `end = 4.dp, top = 4.dp` padding to the `CircleIconButton` to give it the same breathing room.

## Before / After

<!-- TODO: drag the before/after screenshots here -->

## Test plan
- [ ] Add the Gitling widget to the home screen
- [ ] Confirm the refresh button has visible margin from the top-right corner, matching the logo's clearance on the left
- [ ] Tap refresh -- still works