### PR TITLE
fix(ci): replace retired ubuntu-20.04 runner with ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ on:
     types: [opened, synchronize]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: set up JDK 21
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 21
     - name: Build with Gradle
       run: ./gradlew --no-daemon clean assembleDebug testDebug


### PR DESCRIPTION
## Summary

- The \`Build\` workflow's \`runs-on: ubuntu-20.04\` has been set since 2021 and never touched since.
- GitHub retired the \`ubuntu-20.04\` hosted runner image in April 2025 -- since then, every `pull_request` Build check has queued forever and hit GitHub's 24h auto-cancel. Checked all 22 runs in this repo's visible history: none have ever completed.
- Bumps \`runs-on\` to \`ubuntu-latest\`, \`actions/checkout\`/\`actions/setup-java\` to v4, and the CI JDK from 11 to 21 -- matching the toolchain pin in \`app/build.gradle.kts\` and the already-working \`release.yml\` (which uses this exact combination successfully on every tagged release).

## Test plan
- [ ] Confirm the Build check on this PR actually completes (green or red, not stuck queued)
- [ ] Confirm it runs `assembleDebug` and `testDebug` successfully