### PR TITLE
fix(clone): keep keyboard from covering input fields in Clone sheet

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repolist/CloneView.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/CloneView.kt
@@ -47,6 +47,7 @@ fun CloneView(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .imePadding()
             .verticalScroll(rememberScrollState())
             .padding(24.dp)
             .padding(bottom = 32.dp)


### PR DESCRIPTION
## Summary

- Reported: when the keyboard comes up in the Clone Repository sheet, the user can't see what they're typing -- the keyboard covers the input field.
- Root cause: `CloneView` is hosted in a `ModalBottomSheet` (`RepoListComposeIntegration.kt`), which draws edge-to-edge and doesn't automatically resize for the IME the way an `AlertDialog` window does (every other text-input dialog in the app -- commit message, add remote, settings edits, etc. -- uses `AlertDialog`, which gets this for free from its own platform Dialog window; `ModalBottomSheet` does not).
- Fix: add `.imePadding()` to the sheet's root `Column`, so the scrollable content reserves space for the keyboard and the focused field scrolls into view above it.
- Audited every other `TextField`/`OutlinedTextField` in the app (commit dialog, add remote, repo config, password prompt, private key generate, settings, accounts, branch chooser sheet) -- all use `AlertDialog` or have no text input, so this `ModalBottomSheet` is the only affected surface.

## Test plan
- [ ] Open Clone Repository sheet, tap Remote URL field, confirm the field and what you type stay visible above the keyboard
- [ ] Same for the Local Path field
- [ ] Scroll the sheet with the keyboard open to confirm nothing is cut off