### PR TITLE
fix(widget): properly move refresh button off the corner

### DIFF
--- a/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
+++ b/app/src/main/java/com/manichord/mgit/widget/RepoWidgetContent.kt
@@ -42,12 +42,16 @@ fun RepoWidgetContent(repos: List<RepoWidgetEntry>) {
                     startIcon = ImageProvider(R.drawable.ic_launcher_foreground),
                     title = "Gitling",
                     actions = {
-                        CircleIconButton(
-                            imageProvider = ImageProvider(R.drawable.ic_sync),
-                            contentDescription = "Refresh",
-                            onClick = actionRunCallback<RefreshWidgetAction>(),
-                            modifier = GlanceModifier.padding(end = 4.dp, top = 4.dp)
-                        )
+                        // Padding must go on a wrapping Box, not CircleIconButton's own
+                        // modifier -- passed directly, it shifts only the icon glyph inside
+                        // the button, not the visible circular background.
+                        Box(modifier = GlanceModifier.padding(end = 8.dp)) {
+                            CircleIconButton(
+                                imageProvider = ImageProvider(R.drawable.ic_sync),
+                                contentDescription = "Refresh",
+                                onClick = actionRunCallback<RefreshWidgetAction>()
+                            )
+                        }
                     }
                 )
             }


### PR DESCRIPTION
## Summary

Follow-up to #30, which didn't actually fix the reported issue.

- #30 passed `padding(end = 4.dp, top = 4.dp)` directly into `CircleIconButton`'s own `modifier` parameter. Verified (via reinstall + pixel measurement at 4dp, 8dp, 16dp, and 60dp) that this only shifts the icon *glyph* inside the button -- the visible circular background stayed at the exact same pixel position every time, so the reported crowding was never actually fixed.
- Also, the `top` padding from #30 was itself a bug: `TitleBar`'s row already vertically centers its children, so adding top-only padding to one child pushes its visible content down within its own (now taller) box -- shifting the button *off* the row's vertical center relative to the title text. Confirmed via measurement: previously off by ~4-8px; removing `top` restored the button to within 1px of the title text's vertical center.
- Fix: wrap `CircleIconButton` in a `Box` and apply `padding(end = 8.dp)` to the *wrapper* instead of the button's own modifier. This moves the whole circle (background + icon) as a unit. Verified the button's visible right edge now sits exactly 8dp (21px at this density) inside the card's edge, matching the padding value.

## Test plan
- [ ] Add the Gitling widget to the home screen
- [ ] Confirm the refresh button has real, visible clearance from the top-right corner
- [ ] Confirm the button is vertically centered with the "Gitling" title text, not shifted down
- [ ] Tap refresh -- still works