### PR TITLE
docs: add Google Play badge now that the listing is live in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <a href="https://github.com/maneeshacooray/Gitling/releases/latest"><img src="https://img.shields.io/github/v/release/maneeshacooray/Gitling?label=GitHub%20release" alt="Latest GitHub release"></a>
   <a href="https://f-droid.org/packages/com.maneeshacooray.gitling/"><img src="https://img.shields.io/f-droid/v/com.maneeshacooray.gitling" alt="F-Droid version"></a>
+  <a href="https://play.google.com/store/apps/details?id=com.maneeshacooray.gitling"><img src="https://img.shields.io/badge/Google%20Play-available-blue?logo=google-play" alt="Available on Google Play"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/maneeshacooray/Gitling" alt="License: GPLv3"></a>
 </p>
 


### PR DESCRIPTION
## Summary

- Adds a "Available on Google Play" badge to README.md, linking to the Play Store listing.
- The GitHub Pages site (gh-pages branch) already had matching Google Play cards added directly (following that branch's existing direct-commit convention, no PR flow there) -- both spots had a `TODO(play-store)` comment marking exactly this, left over from initial site setup pending production approval.

## Test plan
- [ ] Confirm badge renders correctly and links to https://play.google.com/store/apps/details?id=com.maneeshacooray.gitling