### PR TITLE
fix(clone): fix NPE crash validating clone/init with no name typed yet

### DIFF
--- a/app/src/main/java/com/manichord/mgit/clone/CloneViewModel.kt
+++ b/app/src/main/java/com/manichord/mgit/clone/CloneViewModel.kt
@@ -112,7 +112,7 @@ class CloneViewModel(application: Application) : AndroidViewModel(application) {
 
 
     fun cloneRepo() {
-        if (initLocal.value as Boolean) {
+        if (initLocal.value ?: false) {
             Timber.d("INIT LOCAL %s", localRepoName.value)
             initLocalRepo()
         } else {
@@ -134,9 +134,10 @@ class CloneViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun validate() : Boolean {
-        return if (initLocal.value as Boolean) {
-            validateLocalName(localRepoName.value as String)
-        } else validateRemoteUrl(remoteUrl) && validateLocalName(localRepoName.value as String)
+        val localName = localRepoName.value ?: ""
+        return if (initLocal.value ?: false) {
+            validateLocalName(localName)
+        } else validateRemoteUrl(remoteUrl) && validateLocalName(localName)
     }
 
     fun initLocalRepo() {


### PR DESCRIPTION
## Summary

- ACRA report `498d9049-78e1-473f-b3ef-ff2a7d946d32` (v1.0.41, real user on a moto g / Android 16, still reproducible on current `develop`): `NullPointerException: null cannot be cast to non-null type kotlin.String` in `CloneViewModel.validate()`, triggered from `MainActivity.cloneRepo()`.
- Root cause: `localRepoName` is a `MutableLiveData<String>` with no default value, so `.value` is genuinely `null` until the user types something or a remote URL auto-fills it. `validate()` force-cast it with `localRepoName.value as String` instead of a null-safe read. Most directly reachable path: check **Init Local**, tap **Init** immediately without typing a name.
- Fix: read `localRepoName.value ?: ""` once and reuse it, matching the null-coalescing pattern already used a few lines below in `cloneRepo()`. Also hardened the two `initLocal.value as Boolean` casts to the same pattern for consistency (not currently reachable as null since `initLocal` is set synchronously in `init{}`, but same anti-pattern).
- Noted but *not* fixed here (separate, pre-existing issue, out of scope): the Clone/Init button dismisses the bottom sheet unconditionally regardless of what `validate()` returns, so a validation error technically gets set but the sheet is already gone by the time it would render -- see `RepoListComposeIntegration.kt:137-140`.

## Test plan
- [x] Reproduced the exact crash on-device pre-fix (checked Init Local, tapped Init with an empty Local Path field) -- confirmed `NullPointerException` in logcat matching the ACRA report.
- [x] Post-fix: same steps, confirmed no crash (clean logcat, no ACRA report) -- the blank name now correctly fails validation instead.
- [ ] Confirm typing a valid local name and tapping Init still successfully creates a local repo