### PR TITLE
fix(clone): keep the sheet open when Clone/Init validation fails

### DIFF
--- a/app/src/main/java/com/manichord/mgit/MainActivity.kt
+++ b/app/src/main/java/com/manichord/mgit/MainActivity.kt
@@ -614,11 +614,13 @@ class MainActivity : SheimiFragmentActivity() {
         Timber.i("Installed custom HTTPS factory")
     }
 
-    private fun cloneRepo() {
-        if (cloneViewModel.validate()) {
+    private fun cloneRepo(): Boolean {
+        val valid = cloneViewModel.validate()
+        if (valid) {
             hideCloneView()
             cloneViewModel.cloneRepo()
         }
+        return valid
     }
 
     private fun showCloneView() {

--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListComposeIntegration.kt
@@ -41,7 +41,7 @@ fun RepoListComposeContent(
     activity: SheimiFragmentActivity,
     cloneViewModel: CloneViewModel,
     viewModel: RepoListViewModel,
-    onCloneClick: () -> Unit,
+    onCloneClick: () -> Boolean,
     onCancelCloneViewClick: () -> Unit
 ) {
     AppTheme {
@@ -135,8 +135,9 @@ fun RepoListComposeContent(
                 CloneView(
                     viewModel = cloneViewModel,
                     onCloneClick = {
-                        showCloneSheet = false
-                        onCloneClick()
+                        if (onCloneClick()) {
+                            showCloneSheet = false
+                        }
                     },
                     onCancelClick = {
                         showCloneSheet = false


### PR DESCRIPTION
## Summary

Found while reproducing the ACRA NPE crash fixed in #36 -- a separate, pre-existing bug.

- The Clone/Init button in the Clone Repository bottom sheet dismissed the sheet unconditionally, *before* `MainActivity.cloneRepo()` ran validation.
- A failed validation (e.g. blank local name) still set the error LiveData correctly, but the sheet was already gone by the time it would render, so the user just saw the sheet silently close with no feedback at all -- as if nothing happened.
- Fix: `MainActivity.cloneRepo()` now returns whether validation passed. `RepoListComposeContent`'s `onCloneClick` contract changed from `() -> Unit` to `() -> Boolean` so the composable only closes the sheet on success.

## Test plan
- [x] Invalid input (Init Local checked, empty Local Path, tap Init) -- confirmed the sheet now stays open and shows "Repository name required" instead of closing silently.
- [x] Valid input (typed a name, tapped Init) -- confirmed the sheet still closes and the local repo is created correctly, same as before.