### PR TITLE
fix(ssh): validate DSA key length before generating instead of crashing

### DIFF
--- a/app/src/main/java/com/manichord/mgit/ssh/PrivateKeyGenerate.kt
+++ b/app/src/main/java/com/manichord/mgit/ssh/PrivateKeyGenerate.kt
@@ -110,6 +110,9 @@ class PrivateKeyGenerate : SheimiDialogFragment() {
                                     size > 16384 -> {
                                         errorRes = R.string.alert_too_long_key_size
                                     }
+                                    isDsa && size !in setOf(1024, 2048, 3072) -> {
+                                        errorRes = R.string.alert_dsa_key_size
+                                    }
                                     File(PrivateKeyUtils.getPrivateKeyFolder(), newFilename).exists() -> {
                                         errorRes = R.string.alert_key_exists
                                     }

--- a/app/src/main/res/values/strings_error.xml
+++ b/app/src/main/res/values/strings_error.xml
@@ -28,6 +28,7 @@
     <!-- alerts -->
     <string name="alert_too_short_key_size">Keylength is too small (at least 1024 bits for RSA and DSA)</string>
     <string name="alert_too_long_key_size">Keylength is too large</string>
+    <string name="alert_dsa_key_size">DSA only supports key lengths of 1024, 2048, or 3072 bits</string>
     <string name="alert_key_exists">Key already exists</string>
     <string name="alert_field_not_empty">Field should not be empty</string>
     <string name="alert_remoteurl_required">Remote URL required</string>


### PR DESCRIPTION
## Summary

Two separate ACRA reports (v1.0.37, a Pixel 10 Pro and a Samsung SM-A426U -- different users, same root cause):

```
RuntimeException: Failed to generate SSH key
Caused by: com.jcraft.jsch.JSchException: java.lang.IllegalArgumentException: L values must be between 1024 and 3072 and a multiple of 1024
```

- The Generate Key dialog's key-size field defaults to `"4096"` (a reasonable RSA default).
- Validation only checked a generic `1024..16384` range regardless of key type -- it didn't account for DSA's stricter constraint (BouncyCastle/JSch only support exactly 1024, 2048, or 3072 bits for DSA, per FIPS 186).
- Selecting DSA without changing the default key size passes the generic check, then crashes deep inside `KeyPair.genKeyPair()` with no actionable feedback -- the key is silently not created and the only signal is an ACRA report.
- Fix: added a DSA-specific validation branch with a clear error message, same pattern as the existing size/filename checks.

## Test plan
- [x] Selected DSA with the default 4096 key size, tapped Generate key -- confirmed "DSA only supports key lengths of 1024, 2048, or 3072 bits" now shows instead of crashing (clean logcat, no ACRA report).
- [ ] Confirm DSA with a valid size (1024/2048/3072) still generates a key successfully.
- [ ] Confirm RSA key generation is unaffected.