### PR TITLE
fix(pull): don't crash if PullDialog is recreated before its host is set

### DIFF
--- a/app/src/main/java/me/sheimi/sgit/dialogs/PullDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/PullDialog.kt
@@ -36,8 +36,15 @@ class PullDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val remotes = repo.remotes.toList()
 
         return ComposeView(requireContext()).apply {


### PR DESCRIPTION
## Summary

- ACRA report \`d8292e4b-61b8-4b38-8060-d632eb84b206\` (v1.0.36): plain \`NullPointerException\` at \`PullDialog.kt:40\`, from the \`!!\` on \`currentRepoDetailHost\`.
- \`currentRepoDetailHost\` is a plain in-memory \`MainActivity\` field, not persisted across process death -- it's only (re)set once Compose recomposes the \"repoDetail\" NavHost route. A legacy \`DialogFragment\` like \`PullDialog\` can be recreated by the FragmentManager's own state restoration (independent of, and able to precede, Compose recomposition) after the app's process is killed and restarted, calling \`onCreateView()\` while \`currentRepoDetailHost\` is still null.
- This mirrors an already-established pattern in this codebase: \`MainActivity\`'s own \"repoDetail\" composable already bails to the repo list rather than crashing when its pending repo is null after process death. Applied the same defensive bail-out here.

## Also found, not fixed here

Six other dialogs read \`currentRepoDetailHost\` the same unguarded way and are equally exposed to this exact crash class: \`MergeDialog\`, \`RemoveRemoteDialog\`, \`RebaseDialog\`, \`PushDialog\`, \`CheckoutDialog\`, \`RepoFileOperationDialog\`. None have a matching ACRA report yet, so flagging as a candidate follow-up rather than expanding this fix's blast radius across 6 more files unprompted.

## Test plan
- [x] Repo detail's Pull action still opens and works normally when the host is set (the common case) -- confirmed no regression, clean logcat.
- [ ] The null-guard branch itself isn't reliably reproducible via adb (needs true process death + FragmentManager state restoration racing Compose recomposition) -- this is a code-reviewed defensive fix mirroring an established pattern, not one confirmed by directly reproducing the crash.