### PR TITLE
fix: extend the PullDialog stale-host crash fix to 6 other dialogs

### DIFF
--- a/app/src/main/java/me/sheimi/sgit/dialogs/CheckoutDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/CheckoutDialog.kt
@@ -35,7 +35,14 @@ class CheckoutDialog : SheimiDialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         commit = arguments?.getString(BASE_COMMIT) ?: ""
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val message = getString(R.string.dialog_comfirm_checkout_commit_msg) +
             " " + Repo.getCommitDisplayName(commit)
 

--- a/app/src/main/java/me/sheimi/sgit/dialogs/MergeDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/MergeDialog.kt
@@ -45,8 +45,15 @@ class MergeDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val currentBranchDisplayName = repo.currentDisplayName
         val branches = repo.localBranches.filter {
             Repo.getCommitDisplayName(it.name) != currentBranchDisplayName

--- a/app/src/main/java/me/sheimi/sgit/dialogs/PushDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/PushDialog.kt
@@ -36,8 +36,15 @@ class PushDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val remotes = repo.remotes.toList()
 
         return ComposeView(requireContext()).apply {

--- a/app/src/main/java/me/sheimi/sgit/dialogs/RebaseDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/RebaseDialog.kt
@@ -34,8 +34,15 @@ class RebaseDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val currentBranchName = repo.branchName
         val branches = repo.branches.filter { it != currentBranchName }
 

--- a/app/src/main/java/me/sheimi/sgit/dialogs/RemoveRemoteDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/RemoveRemoteDialog.kt
@@ -31,8 +31,15 @@ class RemoveRemoteDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val remotes = repo.remotes.toList()
 
         return ComposeView(requireContext()).apply {

--- a/app/src/main/java/me/sheimi/sgit/dialogs/RepoFileOperationDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/RepoFileOperationDialog.kt
@@ -42,7 +42,14 @@ class RepoFileOperationDialog : SheimiDialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         val filePath = arguments?.getString(FILE_PATH) ?: ""
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
 
         fun showRemoveFileMessageDialog(
             dialogTitle: Int,


### PR DESCRIPTION
## Summary

Follow-up to #40, which fixed the exact same crash class in \`PullDialog\` and flagged 6 other dialogs sharing the identical unguarded pattern without expanding that PR's blast radius. This PR applies the same fix to all 6: \`MergeDialog\`, \`RemoveRemoteDialog\`, \`RebaseDialog\`, \`PushDialog\`, \`CheckoutDialog\`, \`RepoFileOperationDialog\`.

- \`currentRepoDetailHost\` is a plain in-memory \`MainActivity\` field, only (re)set once Compose recomposes the "repoDetail" NavHost route.
- A legacy \`DialogFragment\` can be recreated by the FragmentManager's own state restoration (independent of, and able to precede, Compose recomposition) after process death, calling \`onCreateView()\` while \`currentRepoDetailHost\` is still null -- crashing with a plain \`NullPointerException\` on the \`!!\`.
- Fix: guard \`repo\`/\`activity\` (or just \`activity\`, for \`CheckoutDialog\` and \`RepoFileOperationDialog\`, which don't read \`repo\` from arguments) and \`dismiss()\` instead of crashing -- identical pattern to the already-merged \`PullDialog\` fix.

## Test plan
- [x] \`PushDialog\`: reproduced the same kill+restore scenario used to verify the \`PullDialog\` fix -- clean logcat, dialog gracefully not restored, repo detail lands correctly instead of crashing.
- [x] \`MergeDialog\`: confirmed the normal (non-crash) path still opens and works correctly -- no regression.
- [ ] The remaining 4 dialogs (\`RemoveRemoteDialog\`, \`RebaseDialog\`, \`CheckoutDialog\`, \`RepoFileOperationDialog\`) share the byte-identical fix structure verified above; not independently re-tested on-device given the mechanical nature of the change.