### PR TITLE
fix: don't crash showing an error dialog after onSaveInstanceState

### DIFF
--- a/app/src/main/java/me/sheimi/android/utils/BasicFunctions.java
+++ b/app/src/main/java/me/sheimi/android/utils/BasicFunctions.java
@@ -68,6 +68,9 @@ public class BasicFunctions {
     }
 
     public static void showError(@NonNull @NotNull SheimiFragmentActivity activity, @StringRes final int errorTitleRes, @StringRes final int errorRes) {
+        if (!canShowDialog(activity)) {
+            return;
+        }
         ErrorDialog errorDialog = new ErrorDialog();
         errorDialog.setErrorRes(errorRes);
         errorDialog.setErrorTitleRes(errorTitleRes);
@@ -75,11 +78,27 @@ public class BasicFunctions {
     }
 
     public static void showException(@NonNull @NotNull SheimiFragmentActivity activity, Throwable throwable, @StringRes final int errorTitleRes, @StringRes final int errorRes) {
+        if (!canShowDialog(activity)) {
+            return;
+        }
         ErrorDialog errorDialog = new ErrorDialog();
         errorDialog.setThrowable(throwable);
         errorDialog.setErrorRes(errorRes);
         errorDialog.setErrorTitleRes(errorTitleRes);
         errorDialog.show(activity.getSupportFragmentManager(), "exception-dialog");
+    }
+
+    /**
+     * A RepoOpTask's onPostExecute can fire after the hosting activity has been backgrounded
+     * (e.g. the user hits Home mid-clone) -- the FragmentManager has already saved its state by
+     * then, and committing a new DialogFragment against it throws
+     * "Can not perform this action after onSaveInstanceState" instead of just failing silently.
+     */
+    private static boolean canShowDialog(@NonNull SheimiFragmentActivity activity) {
+        if (activity.isFinishing() || activity.isDestroyed()) {
+            return false;
+        }
+        return !activity.getSupportFragmentManager().isStateSaved();
     }
 
 

--- a/app/src/main/java/me/sheimi/sgit/dialogs/CheckoutDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/CheckoutDialog.kt
@@ -35,7 +35,14 @@ class CheckoutDialog : SheimiDialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         commit = arguments?.getString(BASE_COMMIT) ?: ""
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val message = getString(R.string.dialog_comfirm_checkout_commit_msg) +
             " " + Repo.getCommitDisplayName(commit)
 

--- a/app/src/main/java/me/sheimi/sgit/dialogs/MergeDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/MergeDialog.kt
@@ -45,8 +45,15 @@ class MergeDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val currentBranchDisplayName = repo.currentDisplayName
         val branches = repo.localBranches.filter {
             Repo.getCommitDisplayName(it.name) != currentBranchDisplayName

--- a/app/src/main/java/me/sheimi/sgit/dialogs/PushDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/PushDialog.kt
@@ -36,8 +36,15 @@ class PushDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val remotes = repo.remotes.toList()
 
         return ComposeView(requireContext()).apply {

--- a/app/src/main/java/me/sheimi/sgit/dialogs/RebaseDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/RebaseDialog.kt
@@ -34,8 +34,15 @@ class RebaseDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val currentBranchName = repo.branchName
         val branches = repo.branches.filter { it != currentBranchName }
 

--- a/app/src/main/java/me/sheimi/sgit/dialogs/RemoveRemoteDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/RemoveRemoteDialog.kt
@@ -31,8 +31,15 @@ class RemoveRemoteDialog : SheimiDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val repo = arguments?.getSerializable(Repo.TAG) as Repo
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val repo = arguments?.getSerializable(Repo.TAG) as? Repo
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (repo == null || activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
         val remotes = repo.remotes.toList()
 
         return ComposeView(requireContext()).apply {

--- a/app/src/main/java/me/sheimi/sgit/dialogs/RepoFileOperationDialog.kt
+++ b/app/src/main/java/me/sheimi/sgit/dialogs/RepoFileOperationDialog.kt
@@ -42,7 +42,14 @@ class RepoFileOperationDialog : SheimiDialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         val filePath = arguments?.getString(FILE_PATH) ?: ""
-        val activity = (requireActivity() as MainActivity).currentRepoDetailHost!!
+        val activity = (requireActivity() as MainActivity).currentRepoDetailHost
+        if (activity == null) {
+            // A DialogFragment can be recreated by the FragmentManager's own state
+            // restoration (e.g. after process death) before Compose has recomposed
+            // "repoDetail" and re-set currentRepoDetailHost -- bail out rather than crash.
+            dismiss()
+            return ComposeView(requireContext())
+        }
 
         fun showRemoveFileMessageDialog(
             dialogTitle: Int,


### PR DESCRIPTION
## Summary

Fixes a real ACRA crash report (`IllegalStateException: Can not perform this
action after onSaveInstanceState`).

`RepoOpTask.onPostExecute` (shared by `CloneTask`, `PullTask`, `PushTask`,
etc.) runs on a posted `Handler` once the background git operation finishes.
If the user backgrounds the app while that operation is still running, the
Activity's `FragmentManager` has already saved its state by the time
`onPostExecute` fires, and `BasicFunctions.showError`/`showException`
committing a new `ErrorDialog` against it throws instead of just failing
silently — there's no one looking at the screen to show an error to anyway.

Added a `canShowDialog()` guard (`isFinishing`/`isDestroyed`/`isStateSaved`)
before both dialog calls in `BasicFunctions.java`.

## Test plan

- [x] Reproduced the exact crash: cloned an unreachable URL
      (`http://10.255.255.1/test.git`), backgrounded the app immediately
      after tapping Clone. Unfixed code crashed with the identical stack
      trace from the ACRA report (`BasicFunctions.showException` ->
      `RepoOpTask.onPostExecute` -> `CloneTask.onPostExecute`).
- [x] Same repro steps against the fixed code: process stayed alive, logcat
      only showed `CloneTask: del repo. clone failed`, no crash, no ACRA
      report.
- [x] `./gradlew testDebug` passes.