### PR TITLE
fix: NoSuchMethodError opening/initializing a repo on Android < 13

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,15 +7,16 @@ plugins {
 // ---------------------------------------------------------------------------
 // JGit Android 12 compatibility — bytecode patch
 //
-// JGit 6.3+ uses InputStream.transferTo() (API 29) and JGit 6.7+ uses
-// InputStream.readNBytes(int) (API 33). Neither is available on Android 12
-// (API 31), and desugar_jdk_libs 2.x does not backport either.
+// JGit 6.3+ uses InputStream.transferTo() (API 29) and JGit 6.7+ uses both
+// InputStream.readNBytes(int) and InputStream.readNBytes(byte[], int, int)
+// (API 33). None of these are available on Android 12 (API 31), and
+// desugar_jdk_libs 2.x does not backport any of them.
 //
-// Solution: at build time, rewrite every INVOKEVIRTUAL call to those two
-// methods inside JGit classes into INVOKESTATIC calls to StreamCompat shims
-// that are Java-8-compatible. The stack layout is identical for both opcodes
-// (object reference is already first on the stack), so no extra bytecode is
-// emitted.  StreamCompat lives in me.sheimi.sgit.compat.
+// Solution: at build time, rewrite every INVOKEVIRTUAL call to those methods
+// inside JGit classes into INVOKESTATIC calls to StreamCompat shims that are
+// Java-8-compatible. The stack layout is identical for both opcodes (object
+// reference is already first on the stack), so no extra bytecode is emitted.
+// StreamCompat lives in me.sheimi.sgit.compat.
 // ---------------------------------------------------------------------------
 
 import com.android.build.api.instrumentation.AsmClassVisitorFactory
@@ -46,7 +47,17 @@ abstract class JGitCompatClassVisitorFactory :
                 opcode: Int, owner: String, name: String,
                 descriptor: String, isInterface: Boolean
             ) {
-                if (opcode == Opcodes.INVOKEVIRTUAL && owner == "java/io/InputStream") {
+                // owner is the *compile-time* static type of the receiver, which for calls made
+                // through JGit's own InputStream subclasses (e.g. SilentFileInputStream) is that
+                // subclass, not java/io/InputStream itself -- matching only the exact JDK owner
+                // silently left those call sites unpatched (see JGit-on-old-Android crash where
+                // IO.readFully(File, int) calls SilentFileInputStream.readNBytes(int) directly).
+                // isInstrumentable() below already restricts this whole visitor to
+                // org.eclipse.jgit.* classes, so it's safe to match by name+descriptor across any
+                // owner in that scope rather than requiring java/io/InputStream exactly.
+                if (opcode == Opcodes.INVOKEVIRTUAL &&
+                    (owner == "java/io/InputStream" || owner.startsWith("org/eclipse/jgit/"))
+                ) {
                     when {
                         name == "readNBytes" && descriptor == "(I)[B" -> {
                             super.visitMethodInsn(
@@ -54,6 +65,16 @@ abstract class JGitCompatClassVisitorFactory :
                                 "me/sheimi/sgit/compat/StreamCompat",
                                 "readNBytes",
                                 "(Ljava/io/InputStream;I)[B",
+                                false
+                            )
+                            return
+                        }
+                        name == "readNBytes" && descriptor == "([BII)I" -> {
+                            super.visitMethodInsn(
+                                Opcodes.INVOKESTATIC,
+                                "me/sheimi/sgit/compat/StreamCompat",
+                                "readNBytes",
+                                "(Ljava/io/InputStream;[BII)I",
                                 false
                             )
                             return

--- a/app/src/main/java/me/sheimi/sgit/compat/StreamCompat.java
+++ b/app/src/main/java/me/sheimi/sgit/compat/StreamCompat.java
@@ -3,7 +3,9 @@ package me.sheimi.sgit.compat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 // Java-8-compatible fallbacks for InputStream methods absent on Android < API 33 / 29.
 // JGitCompatPlugin rewrites JGit bytecode at build time to call these instead of the
@@ -15,16 +17,65 @@ public final class StreamCompat {
     private StreamCompat() {}
 
     // Replacement for InputStream.readNBytes(int) — available natively only on API 33+.
+    //
+    // Reads in bounded BUFFER_SIZE chunks rather than eagerly allocating a single `len`-sized
+    // array up front, matching the real JDK implementation -- callers (JGit included) use
+    // Integer.MAX_VALUE as a "read everything" idiom, relying on readNBytes to stop at EOF
+    // instead of actually allocating a multi-gigabyte buffer.
     public static byte[] readNBytes(InputStream in, int len) throws IOException {
         if (len < 0) throw new IllegalArgumentException("len < 0");
-        byte[] buf = new byte[len];
-        int totalRead = 0;
-        while (totalRead < len) {
-            int n = in.read(buf, totalRead, len - totalRead);
-            if (n < 0) break;
-            totalRead += n;
+        List<byte[]> chunks = null;
+        byte[] result = null;
+        int total = 0;
+        int remaining = len;
+        int n;
+        do {
+            byte[] buf = new byte[Math.min(remaining, BUFFER_SIZE)];
+            int nread = 0;
+            while ((n = in.read(buf, nread, buf.length - nread)) > 0) {
+                nread += n;
+                remaining -= n;
+                if (nread == buf.length) break;
+            }
+            if (nread > 0) {
+                byte[] chunk = nread == buf.length ? buf : Arrays.copyOf(buf, nread);
+                if (result == null) {
+                    result = chunk;
+                } else {
+                    if (chunks == null) {
+                        chunks = new ArrayList<>();
+                        chunks.add(result);
+                    }
+                    chunks.add(chunk);
+                }
+                total += nread;
+            }
+        } while (n >= 0 && remaining > 0);
+
+        if (chunks == null) {
+            return result == null ? new byte[0] : result;
         }
-        return totalRead == len ? buf : Arrays.copyOf(buf, totalRead);
+        byte[] combined = new byte[total];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, combined, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return combined;
+    }
+
+    // Replacement for InputStream.readNBytes(byte[], int, int) — available natively only on API 33+.
+    public static int readNBytes(InputStream in, byte[] b, int off, int len) throws IOException {
+        if (off < 0 || len < 0 || off + len > b.length || off + len < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        int n = 0;
+        while (n < len) {
+            int count = in.read(b, off + n, len - n);
+            if (count < 0) break;
+            n += count;
+        }
+        return n;
     }
 
     // Replacement for InputStream.transferTo(OutputStream) — available natively only on API 29+.


### PR DESCRIPTION
## Summary

Fixes #43. JGit calls `InputStream.readNBytes(int)`,
`InputStream.readNBytes(byte[], int, int)`, and
`InputStream.transferTo(OutputStream)` directly -- Java 9+ APIs only present
on Android from API 33/29 respectively. This repo already has a build-time
ASM bytecode patch (`JGitCompatClassVisitorFactory` in `app/build.gradle.kts`)
that redirects those calls to Java-8-compatible `StreamCompat` shims, but it
had two gaps:

1. It only matched calls whose bytecode owner was exactly
   `java/io/InputStream`. JGit's `IO.readFully(File, int)` /
   `IO.readSome(File, int)` call `readNBytes(int)` directly on
   `SilentFileInputStream` (JGit's own `FileInputStream` subclass), so the
   owner in that `invokevirtual` is `SilentFileInputStream`, not
   `InputStream` -- the exact-owner check silently left those call sites
   unpatched. This is precisely the crash in #43: `Git.open()` ->
   `RepositoryCache$FileKey.isGitRepository()` -> `readFirstLine()` ->
   `IO.readFully(File, int)` -> `SilentFileInputStream.readNBytes(int)`.
2. `readNBytes(byte[], int, int)` (the 3-arg overload used by
   `IO.readFully(InputStream, byte[], int, int)` and the pack
   object-size-index classes -- both hot paths during clone/fetch/pull) was
   never matched by the visitor at all, regardless of owner.

Fix: broaden the owner match to any class under `org.eclipse.jgit.*` (the
visitor is already scoped to that package via `isInstrumentable()`, so this
doesn't widen what gets touched), and add the missing
`readNBytes(byte[],int,int)` redirect + `StreamCompat` shim.

Also fixes a bug caught while manually testing this fix: the first version
of `StreamCompat.readNBytes(InputStream, int)` eagerly allocated a
`len`-sized array up front. JGit calls this with `Integer.MAX_VALUE` as a
"read everything until EOF" idiom, which crashed with `OutOfMemoryError`
trying to allocate ~2GB. Rewrote it to read in bounded 8KB chunks and only
allocate what's actually read, matching the real JDK implementation.

## Test plan

- [x] **Real before/after crash repro on a genuine Android 10 (API 29)
      emulator**, matching the reporter's exact device:
  - Unfixed build (v1.0.53): tapped Init on a new local repo, crashed with
    the identical stack trace from the ACRA report.
  - Fixed build: identical steps, no crash -- repo initializes and appears
    in the list.
- [x] Static analysis: dexdump'd the built APK's 23 dex files, confirmed
      zero remaining raw `invoke-virtual` calls to
      `readNBytes`/`transferTo` anywhere in JGit classes.
- [x] Functional regression check: cloned a real repo
      (`github.com/octocat/Hello-World`) to exercise the pack-reading
      `readNBytes(byte[],int,int)` path end-to-end.
- [x] `./gradlew testDebug` passes.