### PR TITLE
fix: add leading slash to .git deep-link pathPattern

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,7 +205,7 @@
     <string name="initialising">Initialising … </string>
     <string name="git" translatable="false">git</string>
     <string name="git_extension" translatable="false">.git</string>
-    <string name="ending_with_git" translatable="false">.*\\.git</string>
+    <string name="ending_with_git" translatable="false">/.*\\.git</string>
     <string name="ssh" translatable="false">ssh</string>
     <string name="github.com" translatable="false">github.com</string>
     <string name="gitlab.com" translatable="false">gitlab.com</string>


### PR DESCRIPTION
## Summary

Play Console's Deep Links checker flags the `*://.*\.git` intent-filter
(the wildcard scheme + pathPattern filter that offers Gitling as a handler
for any URL ending in `.git`, regardless of host) as "Deep link not
working," with the specific recommendation to add a leading `/` to the
`android:pathPattern` attribute -- a URI's path component always begins
with `/`, and this is required for Play's App Links compatibility checks.

One-line fix to the `ending_with_git` string resource used by that
`<data android:pathPattern="@string/ending_with_git" />` element.

## Test plan

- [x] `./gradlew assembleDebug testDebug` passes.
- [ ] Not independently verified via local emulator testing -- `adb`-based
      resolution testing for this specific filter turned out to be
      inconclusive in this environment: Chrome (set as the default browser
      role) intercepts all `http`/`https` `VIEW` intents regardless of any
      other app's declared filters unless that app has *verified* App Links
      for the exact domain, and a synthetic custom scheme used to probe
      around that limitation failed to resolve to any app at all (both
      before and after this change) -- an `adb`/`am start` limitation for
      made-up schemes, not a reflection of the app's actual behavior. This
      is a low-risk, one-line resource string change matching Google's
      documented `pathPattern` syntax and their own linter's exact
      recommendation; Play Console's own Deep Links report after the next
      release is the most reliable way to confirm this specific check
      clears.