### PR TITLE
fix: recover from EACCES when diffing or staging a media file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,12 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Requested lazily (see SheimiFragmentActivity.requestMediaImagesPermission) only when a
+         diff or stage operation actually hits the scoped-storage EACCES this works around
+         (see FsUtils.findEaccesFile). READ_MEDIA_IMAGES is the API 33+ permission; below that,
+         READ_EXTERNAL_STORAGE is the equivalent. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 
     <application android:name=".MGitApplication" android:allowBackup="true" android:largeHeap="true" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:logo="@drawable/ic_launcher" android:label="@string/app_name" android:theme="@style/AppTheme">
         <activity android:name="com.manichord.mgit.MainActivity" android:label="@string/app_name" android:exported="true" android:launchMode="singleTask" android:configChanges="orientation|keyboardHidden|screenSize">

--- a/app/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/app/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -1,9 +1,11 @@
 package me.sheimi.android.activities;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
@@ -16,7 +18,10 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.nostra13.universalimageloader.cache.disc.impl.UnlimitedDiskCache;
@@ -237,6 +242,53 @@ public class SheimiFragmentActivity extends AppCompatActivity {
         void onClicked(String username, String password, boolean savePassword);
 
         void onCanceled();
+    }
+
+    /**
+     * Callback for {@link #requestMediaImagesPermission}, mirroring the {@link OnPasswordEntered}
+     * pattern used for auth retries -- the caller's failed task is already done by the time this
+     * fires (the permission dialog is async), so onGranted() is expected to start a fresh task
+     * rather than resume the old one.
+     */
+    public static interface OnPermissionResult {
+        void onGranted();
+
+        void onDenied();
+    }
+
+    private OnPermissionResult mPendingMediaPermissionCallback;
+
+    private final ActivityResultLauncher<String> mMediaPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
+                OnPermissionResult callback = mPendingMediaPermissionCallback;
+                mPendingMediaPermissionCallback = null;
+                if (callback == null) {
+                    return;
+                }
+                if (granted) {
+                    callback.onGranted();
+                } else {
+                    callback.onDenied();
+                }
+            });
+
+    /**
+     * Requests whichever runtime permission is needed to read image/video/audio files on this
+     * Android version (READ_MEDIA_IMAGES on API 33+, READ_EXTERNAL_STORAGE below that) -- see
+     * FsUtils.findEaccesFile for the scoped-storage quirk this works around. Safe to call from a
+     * background thread; the actual request always runs on the UI thread. Calls back immediately,
+     * without showing anything, if the permission is already granted.
+     */
+    public void requestMediaImagesPermission(final OnPermissionResult callback) {
+        final String permission = Build.VERSION.SDK_INT >= 33
+                ? Manifest.permission.READ_MEDIA_IMAGES
+                : Manifest.permission.READ_EXTERNAL_STORAGE;
+        if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) {
+            callback.onGranted();
+            return;
+        }
+        mPendingMediaPermissionCallback = callback;
+        runOnUiThread(() -> mMediaPermissionLauncher.launch(permission));
     }
 
     /* View Utils End */

--- a/app/src/main/java/me/sheimi/android/utils/FsUtils.java
+++ b/app/src/main/java/me/sheimi/android/utils/FsUtils.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import android.content.Context;
 
@@ -119,6 +121,40 @@ public class FsUtils {
             mDir.mkdirs();
         }
         return mDir;
+    }
+
+    /** Matches the message java.io.FileNotFoundException carries on Android when the underlying
+     * open(2) syscall fails, e.g. "/path/to/file.jpg: open failed: EACCES (Permission denied)". */
+    private static final Pattern EACCES_PATH_PATTERN =
+            Pattern.compile("^(.*): open failed: EACCES");
+
+    /** Walks the cause chain of {@code t} looking for the file an EACCES failure was reported
+     * against, or null if none of the causes match that pattern. On recent Android, MediaProvider
+     * denies raw File access to image/video/audio files -- even ones sitting inside this app's
+     * own Android/media/&lt;pkg&gt; directory (used when "Make repos visible to other apps" is
+     * on) -- unless the app holds READ_MEDIA_IMAGES (or READ_EXTERNAL_STORAGE pre-API 33). JGit's
+     * FileTreeIterator/AddCommand open working-tree files directly via java.io.File, so diffing or
+     * staging such a file throws this before Gitling gets a chance to ask for that permission. */
+    public static File findEaccesFile(Throwable t) {
+        while (t != null) {
+            String msg = t.getMessage();
+            if (msg != null) {
+                Matcher matcher = EACCES_PATH_PATTERN.matcher(msg);
+                if (matcher.find()) {
+                    return new File(matcher.group(1));
+                }
+            }
+            t = t.getCause();
+        }
+        return null;
+    }
+
+    /** Wraps an EACCES failure (see {@link #findEaccesFile}) with a message explaining the likely
+     * cause and next step, in place of JGit's raw "open failed: EACCES" message. */
+    public static Throwable wrapEaccesFile(Throwable cause, File eaccesFile) {
+        String friendly = MGitApplication.getContext()
+                .getString(R.string.error_media_permission_denied, eaccesFile.getName());
+        return new IOException(friendly, cause);
     }
 
     public static String getMimeType(String url) {

--- a/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/AddToStageTask.java
+++ b/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/AddToStageTask.java
@@ -1,5 +1,10 @@
 package me.sheimi.sgit.repo.tasks.repo;
 
+import java.io.File;
+
+import me.sheimi.android.activities.SheimiFragmentActivity;
+import me.sheimi.android.utils.BasicFunctions;
+import me.sheimi.android.utils.FsUtils;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.exception.StopTaskException;
@@ -9,15 +14,25 @@ public class AddToStageTask extends RepoOpTask {
 
     public String mFilePattern;
     private AsyncTaskPostCallback mCallback;
+    private final boolean mIsMediaPermissionRetry;
 
     public AddToStageTask(Repo repo, String filepattern) {
         this(repo, filepattern, null);
     }
 
     public AddToStageTask(Repo repo, String filepattern, AsyncTaskPostCallback callback) {
+        this(repo, filepattern, callback, false);
+    }
+
+    /** @param isMediaPermissionRetry true only for the single retry instance
+     * retryAfterMediaPermission constructs -- caps that retry at one attempt (see there for why
+     * a hard cap, not just checking the permission again, is required). */
+    private AddToStageTask(Repo repo, String filepattern, AsyncTaskPostCallback callback,
+                           boolean isMediaPermissionRetry) {
         super(repo);
         mFilePattern = filepattern;
         mCallback = callback;
+        mIsMediaPermissionRetry = isMediaPermissionRetry;
         setSuccessMsg(R.string.success_add_to_stage);
     }
 
@@ -39,9 +54,62 @@ public class AddToStageTask extends RepoOpTask {
         } catch (StopTaskException e) {
             return false;
         } catch (Throwable e) {
-            setException(e);
+            File eaccesFile = FsUtils.findEaccesFile(e);
+            if (eaccesFile == null) {
+                setException(e);
+            } else if (mIsMediaPermissionRetry || !retryAfterMediaPermission(e, eaccesFile)) {
+                setException(FsUtils.wrapEaccesFile(e, eaccesFile));
+            }
+            // else: a permission prompt is in flight and will silently retry via a fresh task on
+            // its own if granted -- this attempt's own error dialog is suppressed below so it
+            // doesn't flash up alongside (or after) a retry that's about to succeed.
             return false;
         }
+        return true;
+    }
+
+    /** See FsUtils.findEaccesFile -- asks for the runtime permission the EACCES was actually
+     * about, then (if granted) reruns this task from scratch, mirroring how RepoRemoteOpTask
+     * retries after an auth prompt. Returns whether a request was actually kicked off (false if
+     * there's no active activity to ask from, in which case the caller shows the normal error
+     * dialog instead).
+     *
+     * <p>The retry is capped at exactly one attempt (see mIsMediaPermissionRetry) rather than
+     * re-checking the permission indefinitely -- confirmed on-device that after certain photo
+     * picker choices (e.g. "Don't select more" without picking this specific file), Android
+     * reports READ_MEDIA_IMAGES as granted via checkSelfPermission while MediaProvider's own
+     * per-file check still denies this exact file, which would otherwise retry forever. */
+    private boolean retryAfterMediaPermission(final Throwable cause, final File eaccesFile) {
+        SheimiFragmentActivity activity = BasicFunctions.getActiveActivity();
+        if (activity == null) {
+            return false;
+        }
+        // Suppresses this attempt's own error dialog (see RepoOpTask#onPostExecute) -- its
+        // outcome is superseded by the fresh task the permission callback below starts, or by
+        // the error dialog onDenied() raises directly if the user declines.
+        cancelTask();
+        // Frees the repo's exclusive-task slot right now rather than waiting for this task's own
+        // onPostExecute (which normally does this) to get posted and run -- when the permission
+        // is already granted, requestMediaImagesPermission below calls onGranted() immediately,
+        // still nested inside this very call stack, and the new AddToStageTask it constructs
+        // would otherwise find the slot still held by this one and refuse to start ("A task for
+        // this repo is already running").
+        mRepo.removeTask(this);
+        activity.requestMediaImagesPermission(new SheimiFragmentActivity.OnPermissionResult() {
+            @Override
+            public void onGranted() {
+                new AddToStageTask(mRepo, mFilePattern, mCallback, true).executeTask();
+            }
+
+            @Override
+            public void onDenied() {
+                SheimiFragmentActivity activity = BasicFunctions.getActiveActivity();
+                if (activity != null) {
+                    BasicFunctions.showException(activity, FsUtils.wrapEaccesFile(cause, eaccesFile),
+                            0, R.string.dialog_error_title);
+                }
+            }
+        });
         return true;
     }
 }

--- a/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/CommitDiffTask.java
+++ b/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/CommitDiffTask.java
@@ -1,11 +1,15 @@
 package me.sheimi.sgit.repo.tasks.repo;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
+import me.sheimi.android.activities.SheimiFragmentActivity;
+import me.sheimi.android.utils.BasicFunctions;
+import me.sheimi.android.utils.FsUtils;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.exception.StopTaskException;
@@ -36,6 +40,7 @@ public class CommitDiffTask extends RepoOpTask {
     private Iterable<RevCommit> mCommits;
     private DiffFormatter mDiffFormatter;
     private ByteArrayOutputStream mDiffOutput;
+    private final boolean mIsMediaPermissionRetry;
 
     public interface CommitDiffResult {
         public void pushResult(List<DiffEntry> diffEntries,
@@ -44,11 +49,22 @@ public class CommitDiffTask extends RepoOpTask {
 
     public CommitDiffTask(Repo repo, String oldCommit, String newCommit,
                           CommitDiffResult callback, boolean showDescription) {
+        this(repo, oldCommit, newCommit, callback, showDescription, false);
+    }
+
+    /** @param isMediaPermissionRetry true only for the single retry instance
+     * handleDiffIOException constructs -- caps that retry at one attempt (see
+     * AddToStageTask's counterpart for why a hard cap, not just checking the permission again,
+     * is required). */
+    private CommitDiffTask(Repo repo, String oldCommit, String newCommit,
+                          CommitDiffResult callback, boolean showDescription,
+                          boolean isMediaPermissionRetry) {
         super(repo, false);
         mOldCommit = oldCommit;
         mNewCommit = newCommit;
         mCallback = callback;
         mShowDescription = showDescription;
+        mIsMediaPermissionRetry = isMediaPermissionRetry;
     }
 
     @Override
@@ -132,7 +148,7 @@ public class CommitDiffTask extends RepoOpTask {
         } catch (AmbiguousObjectException e) {
             setException(e, R.string.error_diff_failed);
         } catch (IOException e) {
-            setException(e, R.string.error_diff_failed);
+            handleDiffIOException(e);
         } catch (IllegalStateException e) {
             setException(e, R.string.error_diff_failed);
         } catch (NullPointerException e) {
@@ -153,9 +169,45 @@ public class CommitDiffTask extends RepoOpTask {
             setException(e, R.string.error_diff_failed);
             throw new StopTaskException();
         } catch (IOException e) {
-            setException(e, R.string.error_diff_failed);
+            handleDiffIOException(e);
             throw new StopTaskException();
         }
+    }
+
+    /** See FsUtils.findEaccesFile -- if this IOException is that scoped-storage EACCES, asks for
+     * the runtime permission it's actually about and reruns the whole diff from scratch if
+     * granted, mirroring how RepoRemoteOpTask retries after an auth prompt. Suppresses this
+     * attempt's own error dialog while a request is in flight (see AddToStageTask's counterpart
+     * for why) -- falls back to the normal dialog if there's no active activity to ask from, if
+     * this is already the one retry attempt allowed (see mIsMediaPermissionRetry), or directly
+     * raises one if the user ends up declining. */
+    private void handleDiffIOException(final IOException e) {
+        final File eaccesFile = FsUtils.findEaccesFile(e);
+        if (eaccesFile == null) {
+            setException(e, R.string.error_diff_failed);
+            return;
+        }
+        SheimiFragmentActivity activity = BasicFunctions.getActiveActivity();
+        if (mIsMediaPermissionRetry || activity == null) {
+            setException(FsUtils.wrapEaccesFile(e, eaccesFile), R.string.error_diff_failed);
+            return;
+        }
+        cancelTask();
+        activity.requestMediaImagesPermission(new SheimiFragmentActivity.OnPermissionResult() {
+            @Override
+            public void onGranted() {
+                new CommitDiffTask(mRepo, mOldCommit, mNewCommit, mCallback, mShowDescription, true).executeTask();
+            }
+
+            @Override
+            public void onDenied() {
+                SheimiFragmentActivity activity = BasicFunctions.getActiveActivity();
+                if (activity != null) {
+                    BasicFunctions.showException(activity, FsUtils.wrapEaccesFile(e, eaccesFile),
+                            R.string.error_diff_failed, R.string.dialog_error_title);
+                }
+            }
+        });
     }
 
     public void executeTask() {

--- a/app/src/main/res/values/strings_error.xml
+++ b/app/src/main/res/values/strings_error.xml
@@ -51,5 +51,6 @@
     <string name="alert_file_creation_failure">Couldn\'t create file</string>
     <string name="error_no_repository">No repository found</string>
     <string name="error_submodule_update_failed">Submodule update failed</string>
+    <string name="error_media_permission_denied">Android blocked access to \"%1$s\" because Gitling doesn\'t have permission to read media files yet. Allow it if prompted, or enable photo and video access for Gitling in Android Settings, then try again.</string>
 
 </resources>


### PR DESCRIPTION
## Summary

Fixes #48. Diffing or staging an image (or other recognized media type) sitting in a repo stored under "Make repos visible to other apps" threw a raw EACCES exception instead of a usable error.

**Root cause:** Android's MediaProvider blocks direct `java.io.File` access to image/video/audio files, even ones inside Gitling's own `Android/media/<pkg>/` directory, unless the app holds `READ_MEDIA_IMAGES` (API 33+) or `READ_EXTERNAL_STORAGE` (older). Gitling never declared or requested either permission, so JGit's `FileTreeIterator`/`AddCommand`, which open working-tree files directly, hit `EACCES` before the app got a chance to ask.

**Fix:** the permission is requested lazily, only the moment a diff or stage operation actually hits this EACCES, then the operation retries automatically once granted, mirroring the existing auth-retry pattern already used for password prompts (`RepoRemoteOpTask`/`OnPasswordEntered`). No permission prompt ever appears for users who don't hit this path.

Two issues surfaced during on-device testing and are also fixed here:
- A repo-task-slot race where the retry could start before the failed attempt's slot was freed, surfacing a spurious "task already running" toast.
- An infinite retry loop: Android can report the permission as granted via `checkSelfPermission` while MediaProvider's own per-file check still denies that specific file (observed after choosing "Don't select more" in the system photo picker). The retry is capped at exactly one attempt to avoid looping on that state.

## Test plan

All verified on-device (emulator, API 36), not just read through:
- [x] Reproduced the original bug exactly (matching the issue's screenshots) on the unpatched build; confirmed via logcat the failure is `MediaProvider: calling app has PERMISSION_READ_IMAGES? false`.
- [x] Stage flow: permission denied -> tap stage -> system prompt appears -> grant ("Allow all") -> auto-retry -> "File has been added to stage", no stray error dialog.
- [x] Diff flow: same sequence -> diff renders correctly ("Binary files differ") after grant.
- [x] Partial-grant edge case ("Don't select more"): one clean, accurate error dialog, confirmed no infinite loop (logcat access-attempt count dropped from hundreds/sec to exactly 2 after the fix).
- [x] `./gradlew --no-daemon clean assembleDebug testDebug` passes.