### PR TITLE
fix: patch InputStream.readAllBytes() for JGit on Android API < 33

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,10 +7,16 @@ plugins {
 // ---------------------------------------------------------------------------
 // JGit Android 12 compatibility — bytecode patch
 //
-// JGit 6.3+ uses InputStream.transferTo() (API 29) and JGit 6.7+ uses both
-// InputStream.readNBytes(int) and InputStream.readNBytes(byte[], int, int)
-// (API 33). None of these are available on Android 12 (API 31), and
-// desugar_jdk_libs 2.x does not backport any of them.
+// JGit 6.3+ uses InputStream.transferTo() (API 29) and JGit 6.7+ uses
+// InputStream.readNBytes(int), readNBytes(byte[], int, int), and
+// readAllBytes() (all API 33). None of these are available on Android 12
+// (API 31) or older, and desugar_jdk_libs 2.x does not backport any of them.
+// readAllBytes() specifically is reached from AddCommand.call() ->
+// WorkingTreeIterator.getEntryContentLength() -> possiblyFilteredLength() ->
+// IO.readWholeStream() whenever a staged file is <= 64KB and either has a
+// .gitattributes clean filter or needs EOL conversion -- confirmed by
+// decompiling org.eclipse.jgit:org.eclipse.jgit:7.3.0 with javap and
+// reproduced live on an API 29 emulator (see issue #52).
 //
 // Solution: at build time, rewrite every INVOKEVIRTUAL call to those methods
 // inside JGit classes into INVOKESTATIC calls to StreamCompat shims that are
@@ -59,6 +65,16 @@ abstract class JGitCompatClassVisitorFactory :
                     (owner == "java/io/InputStream" || owner.startsWith("org/eclipse/jgit/"))
                 ) {
                     when {
+                        name == "readAllBytes" && descriptor == "()[B" -> {
+                            super.visitMethodInsn(
+                                Opcodes.INVOKESTATIC,
+                                "me/sheimi/sgit/compat/StreamCompat",
+                                "readAllBytes",
+                                "(Ljava/io/InputStream;)[B",
+                                false
+                            )
+                            return
+                        }
                         name == "readNBytes" && descriptor == "(I)[B" -> {
                             super.visitMethodInsn(
                                 Opcodes.INVOKESTATIC,

--- a/app/src/main/java/me/sheimi/sgit/compat/StreamCompat.java
+++ b/app/src/main/java/me/sheimi/sgit/compat/StreamCompat.java
@@ -64,6 +64,14 @@ public final class StreamCompat {
         return combined;
     }
 
+    // Replacement for InputStream.readAllBytes() — available natively only on API 33+.
+    // The real JDK defines this as readNBytes(Integer.MAX_VALUE) (see java.io.InputStream
+    // source), so delegate to the existing bounded-chunk implementation above rather than
+    // duplicating it.
+    public static byte[] readAllBytes(InputStream in) throws IOException {
+        return readNBytes(in, Integer.MAX_VALUE);
+    }
+
     // Replacement for InputStream.readNBytes(byte[], int, int) — available natively only on API 33+.
     public static int readNBytes(InputStream in, byte[] b, int off, int len) throws IOException {
         if (off < 0 || len < 0 || off + len > b.length || off + len < 0) {


### PR DESCRIPTION
## Summary

Fixes #52. Staging a file crashed with `NoSuchMethodError: No virtual method readAllBytes()[B in class Ljava/io/InputStream` on Android API < 33, since that method was only added to Android in API 33 and isn't backported by desugar_jdk_libs.

**Root cause** (confirmed by decompiling the actual JGit 7.3.0 jar this app ships, with javap): `AddCommand.call()` always calls `WorkingTreeIterator.getEntryContentLength()` when staging any entry, which calls `possiblyFilteredLength()`. That method calls `IO.readWholeStream()`, which calls the missing `InputStream.readAllBytes()`, specifically when a staged file is <= 64KB **and** either has a `.gitattributes` clean filter configured or needs EOL conversion. Plain binary files with no filter skip this path entirely and take a different, already-safe code path (`computeLength()`), so this refines the original report slightly, a large file alone does not trigger it.

This is a gap in the existing `JGitCompatClassVisitorFactory` ASM bytecode patch in `app/build.gradle.kts` (added for the v1.0.54 Android 12 fix), which already redirects `readNBytes(int)`, `readNBytes(byte[],int,int)`, and `transferTo(OutputStream)` to Java-8-compatible `StreamCompat` shims, but never covered this fourth method.

## Fix

- `StreamCompat.readAllBytes(InputStream)`, delegating to the existing `readNBytes(in, Integer.MAX_VALUE)` — this matches how the real JDK itself defines `readAllBytes()`, so no new logic to maintain.
- Extended the ASM patch to redirect the `()[B` descriptor the same way as the other three methods.

## Test plan

- [x] Reproduced live on an `android10_arm64` (API 29) emulator: repo with a `.gitattributes` containing `* text=auto` and a small text file, staged via the "+" button, exact same stack trace as the report.
- [x] Rebuilt with the fix, reinstalled on the same emulator, same repro now succeeds cleanly ("File has been added to stage"), zero exceptions in logcat.
- [x] `./gradlew --no-daemon clean assembleDebug testDebug` passes.