### PR TITLE
feat: expose repos as a browsable Gitling location for other apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,18 @@
             <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/filepaths" />
         </provider>
 
+        <!-- Exposes repos as a browsable "Gitling" location in the Files app and SAF pickers
+             (issue #49). android:permission="android.permission.MANAGE_DOCUMENTS" is the
+             standard DocumentsProvider protection: only the system's DocumentsUI holds that
+             permission, so despite exported="true" no third-party app can talk to this
+             provider directly; everything goes through the system picker and the per-document
+             grants the user makes there. -->
+        <provider android:name="com.manichord.mgit.documents.GitlingDocumentsProvider" android:authorities="com.maneeshacooray.gitling.documents" android:exported="true" android:grantUriPermissions="true" android:permission="android.permission.MANAGE_DOCUMENTS">
+            <intent-filter>
+                <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+            </intent-filter>
+        </provider>
+
         <receiver android:name="com.manichord.mgit.widget.RepoListWidgetReceiver" android:exported="false" android:label="@string/widget_label">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/app/src/main/java/com/manichord/mgit/documents/GitlingDocumentsProvider.kt
+++ b/app/src/main/java/com/manichord/mgit/documents/GitlingDocumentsProvider.kt
@@ -1,0 +1,285 @@
+package com.manichord.mgit.documents
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsProvider
+import android.webkit.MimeTypeMap
+import java.io.File
+import java.io.FileNotFoundException
+import me.sheimi.sgit.MGitApplication
+import me.sheimi.sgit.R
+import me.sheimi.sgit.database.RepoDbManager
+import me.sheimi.sgit.database.models.Repo
+import timber.log.Timber
+
+/**
+ * Exposes every repo's working tree as a browsable "Gitling" location in the system Files app
+ * and any SAF file picker (issue #49) -- the platform-sanctioned way to let other apps read and
+ * edit repo files without Gitling holding any storage permission, and without the repos having
+ * to leave the app's own storage.
+ *
+ * Document ids are "repo:<dbId>" (repo root dir) and "repo:<dbId>/<relative/path>" -- keyed by
+ * the repo's stable database id, NOT its folder name, so grants other apps persist keep working
+ * across a repo rename. The synthetic top-level id is just "root".
+ *
+ * Deliberate constraints:
+ * - `.git` is hidden from listings and unresolvable by id, so no external app can touch repo
+ *   internals through this provider.
+ * - All mutations (write-mode open, create, delete, rename) are refused while the repo's
+ *   exclusive-task slot is held (see Repo.hasOngoingTask), so an external editor can't race a
+ *   checkout/pull/merge that is rewriting the same working tree. The opposite ordering (a git
+ *   op starting while an external write is in flight) is not detectable from here and is
+ *   accepted, matching what the shared-media-storage option already allows today.
+ * - Every method may be invoked by a binder call before MGitApplication.onCreate() has run in
+ *   this process (providers are published to the ActivityManager before Application.onCreate),
+ *   so nothing is touched in onCreate() and repo enumeration degrades to empty until the app
+ *   singleton is ready.
+ */
+class GitlingDocumentsProvider : DocumentsProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun queryRoots(projection: Array<String>?): Cursor {
+        val result = MatrixCursor(projection ?: DEFAULT_ROOT_PROJECTION)
+        result.newRow().apply {
+            add(Root.COLUMN_ROOT_ID, ROOT_ID)
+            add(Root.COLUMN_DOCUMENT_ID, ROOT_DOC_ID)
+            add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
+            add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+            add(
+                Root.COLUMN_FLAGS,
+                Root.FLAG_LOCAL_ONLY or Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD
+            )
+        }
+        return result
+    }
+
+    override fun queryDocument(documentId: String, projection: Array<String>?): Cursor {
+        val result = MatrixCursor(projection ?: DEFAULT_DOCUMENT_PROJECTION)
+        if (documentId == ROOT_DOC_ID) {
+            addRootDocRow(result)
+        } else {
+            val resolved = resolve(documentId)
+            addFileRow(result, documentId, resolved)
+        }
+        return result
+    }
+
+    override fun queryChildDocuments(
+        parentDocumentId: String, projection: Array<String>?, sortOrder: String?
+    ): Cursor {
+        val result = MatrixCursor(projection ?: DEFAULT_DOCUMENT_PROJECTION)
+        if (parentDocumentId == ROOT_DOC_ID) {
+            for (repo in listRepos()) {
+                val dir = repo.dir
+                if (dir.isDirectory) {
+                    addFileRow(result, repoDocId(repo), Resolved(repo, dir), displayName = repo.localPath)
+                }
+            }
+            return result
+        }
+        val resolved = resolve(parentDocumentId)
+        val children = resolved.file.listFiles() ?: return result
+        for (child in children.sortedBy { it.name.lowercase() }) {
+            if (child.name == GIT_DIR) continue
+            addFileRow(result, childDocId(parentDocumentId, child.name), Resolved(resolved.repo, child))
+        }
+        return result
+    }
+
+    override fun openDocument(
+        documentId: String, mode: String, signal: CancellationSignal?
+    ): ParcelFileDescriptor {
+        val resolved = resolve(documentId)
+        if (mode.contains('w') || mode.contains('t')) {
+            failIfRepoBusy(resolved.repo)
+        }
+        return ParcelFileDescriptor.open(resolved.file, ParcelFileDescriptor.parseMode(mode))
+    }
+
+    override fun createDocument(
+        parentDocumentId: String, mimeType: String, displayName: String
+    ): String {
+        val parent = resolve(parentDocumentId)
+        failIfRepoBusy(parent.repo)
+        requireSafeName(displayName)
+        var target = File(parent.file, displayName)
+        // Match other providers' behaviour when the name is taken: uniquify, don't clobber.
+        var attempt = 1
+        while (target.exists()) {
+            target = File(parent.file, "$displayName (${attempt++})")
+        }
+        val ok = if (mimeType == Document.MIME_TYPE_DIR) target.mkdir() else target.createNewFile()
+        if (!ok) throw FileNotFoundException("Could not create $displayName")
+        return childDocId(parentDocumentId, target.name)
+    }
+
+    override fun deleteDocument(documentId: String) {
+        val resolved = resolve(documentId)
+        if (resolved.isRepoRoot) {
+            // Deleting a whole repo belongs in Gitling's own UI, where it also cleans up the
+            // database entry -- a file manager must not be able to do it as a plain rm -rf.
+            throw UnsupportedOperationException("Repos can only be deleted from within Gitling")
+        }
+        failIfRepoBusy(resolved.repo)
+        if (!resolved.file.deleteRecursively()) {
+            throw FileNotFoundException("Could not delete ${resolved.file.name}")
+        }
+    }
+
+    override fun renameDocument(documentId: String, displayName: String): String {
+        val resolved = resolve(documentId)
+        if (resolved.isRepoRoot) {
+            throw UnsupportedOperationException("Repos can only be renamed from within Gitling")
+        }
+        failIfRepoBusy(resolved.repo)
+        requireSafeName(displayName)
+        val target = File(resolved.file.parentFile, displayName)
+        if (target.exists()) throw FileNotFoundException("$displayName already exists")
+        if (!resolved.file.renameTo(target)) {
+            throw FileNotFoundException("Could not rename ${resolved.file.name}")
+        }
+        return documentId.substringBeforeLast('/') + "/" + displayName
+    }
+
+    override fun isChildDocument(parentDocumentId: String, documentId: String): Boolean {
+        if (parentDocumentId == ROOT_DOC_ID) return documentId != ROOT_DOC_ID
+        return documentId.startsWith("$parentDocumentId/")
+    }
+
+    override fun getDocumentType(documentId: String): String {
+        if (documentId == ROOT_DOC_ID) return Document.MIME_TYPE_DIR
+        return mimeType(resolve(documentId).file)
+    }
+
+    // ------------------------------------------------------------------ internals
+
+    /** A resolved document id: the repo it belongs to and the actual file, already validated
+     * to be inside the repo's working tree and not under `.git`. */
+    private class Resolved(val repo: Repo, val file: File) {
+        val isRepoRoot: Boolean get() = file == repo.dir
+    }
+
+    private fun resolve(documentId: String): Resolved {
+        val body = documentId.removePrefix(REPO_PREFIX)
+        if (body == documentId) throw FileNotFoundException("Unknown document id: $documentId")
+        val repoId = body.substringBefore('/').toIntOrNull()
+            ?: throw FileNotFoundException("Bad document id: $documentId")
+        val repo = listRepos().find { it.getID() == repoId }
+            ?: throw FileNotFoundException("No such repo: $repoId")
+        val relative = body.substringAfter('/', "")
+        val repoDir = repo.dir
+        val file = if (relative.isEmpty()) repoDir else File(repoDir, relative)
+        // Canonical containment check defeats ".." traversal in ids handed to us by other
+        // apps; the .git check keeps repo internals unreachable even by a crafted direct id.
+        val canonical = file.canonicalFile
+        val canonicalRoot = repoDir.canonicalFile
+        if (canonical != canonicalRoot && !canonical.startsWith(canonicalRoot)) {
+            throw FileNotFoundException("Outside repo: $documentId")
+        }
+        if (canonical != canonicalRoot &&
+            canonical.relativeTo(canonicalRoot).path.split(File.separatorChar).any { it == GIT_DIR }
+        ) {
+            // Blocks any `.git` segment at any depth, not just the repo root's own -- a
+            // submodule's nested .git is exactly as off-limits as the top-level one.
+            throw FileNotFoundException("Outside repo: $documentId")
+        }
+        if (!file.exists()) throw FileNotFoundException("Not found: $documentId")
+        return Resolved(repo, file)
+    }
+
+    /** All resolvable repos, or empty if the app singleton isn't initialized yet (see class
+     * doc) or the database can't be read for any other reason -- the provider must never take
+     * the Files app down with it. */
+    private fun listRepos(): List<Repo> {
+        return try {
+            Repo.getRepoList(MGitApplication.getContext(), RepoDbManager.queryAllRepo())
+                .filter { !it.isExternal }
+        } catch (e: Exception) {
+            Timber.w(e, "documents provider queried before app init or with unreadable db")
+            emptyList()
+        }
+    }
+
+    private fun failIfRepoBusy(repo: Repo) {
+        if (repo.hasOngoingTask()) {
+            throw IllegalStateException("A git operation is running on this repo; try again shortly")
+        }
+    }
+
+    private fun addRootDocRow(cursor: MatrixCursor) {
+        cursor.newRow().apply {
+            add(Document.COLUMN_DOCUMENT_ID, ROOT_DOC_ID)
+            add(Document.COLUMN_DISPLAY_NAME, context!!.getString(R.string.app_name))
+            add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR)
+            add(Document.COLUMN_FLAGS, 0)
+            add(Document.COLUMN_SIZE, null)
+            add(Document.COLUMN_LAST_MODIFIED, null)
+        }
+    }
+
+    private fun addFileRow(
+        cursor: MatrixCursor, documentId: String, resolved: Resolved, displayName: String? = null
+    ) {
+        val file = resolved.file
+        val flags = if (file.isDirectory) {
+            if (resolved.isRepoRoot) {
+                Document.FLAG_DIR_SUPPORTS_CREATE
+            } else {
+                Document.FLAG_DIR_SUPPORTS_CREATE or Document.FLAG_SUPPORTS_DELETE or
+                    Document.FLAG_SUPPORTS_RENAME
+            }
+        } else {
+            Document.FLAG_SUPPORTS_WRITE or Document.FLAG_SUPPORTS_DELETE or
+                Document.FLAG_SUPPORTS_RENAME
+        }
+        cursor.newRow().apply {
+            add(Document.COLUMN_DOCUMENT_ID, documentId)
+            add(Document.COLUMN_DISPLAY_NAME, displayName ?: file.name)
+            add(Document.COLUMN_MIME_TYPE, mimeType(file))
+            add(Document.COLUMN_FLAGS, flags)
+            add(Document.COLUMN_SIZE, if (file.isFile) file.length() else null)
+            add(Document.COLUMN_LAST_MODIFIED, file.lastModified())
+        }
+    }
+
+    private fun mimeType(file: File): String {
+        if (file.isDirectory) return Document.MIME_TYPE_DIR
+        val extension = file.extension.lowercase()
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+            ?: "application/octet-stream"
+    }
+
+    private fun requireSafeName(displayName: String) {
+        if (displayName.contains('/') || displayName == "." || displayName == ".." ||
+            displayName == GIT_DIR
+        ) {
+            throw IllegalArgumentException("Invalid name: $displayName")
+        }
+    }
+
+    companion object {
+        private const val ROOT_ID = "gitling"
+        private const val ROOT_DOC_ID = "root"
+        private const val REPO_PREFIX = "repo:"
+        private const val GIT_DIR = ".git"
+
+        private fun repoDocId(repo: Repo) = REPO_PREFIX + repo.getID()
+
+        private fun childDocId(parentDocId: String, name: String) = "$parentDocId/$name"
+
+        private val DEFAULT_ROOT_PROJECTION = arrayOf(
+            Root.COLUMN_ROOT_ID, Root.COLUMN_DOCUMENT_ID, Root.COLUMN_TITLE,
+            Root.COLUMN_ICON, Root.COLUMN_FLAGS
+        )
+
+        private val DEFAULT_DOCUMENT_PROJECTION = arrayOf(
+            Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME, Document.COLUMN_MIME_TYPE,
+            Document.COLUMN_FLAGS, Document.COLUMN_SIZE, Document.COLUMN_LAST_MODIFIED
+        )
+    }
+}

--- a/app/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/app/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -235,6 +235,13 @@ public class Repo implements Comparable<Repo>, Serializable {
         mRepoTasks.remove(getID());
     }
 
+    /** Whether this repo's exclusive-task slot (see addTask) is currently held. Used by
+     * GitlingDocumentsProvider to refuse external writes while a git operation (checkout,
+     * pull, merge, ...) may be rewriting the working tree. */
+    public boolean hasOngoingTask() {
+        return mRepoTasks.get(getID()) != null;
+    }
+
     public void updateStatus(String status) {
         ContentValues values = new ContentValues();
         mRepoStatus = status;


### PR DESCRIPTION
## Summary

Addresses #49. Adds a custom `DocumentsProvider` (`GitlingDocumentsProvider`) so every repo's working tree shows up as a "Gitling" location in the system Files app and any SAF file picker (Open, Save, or "choose a folder" flows) -- other apps can read and edit repo files directly, live, with no sync step and no storage permission of any kind.

## Why this approach

Three options were considered for #49 (a request to store repos somewhere reachable by other apps, e.g. Obsidian pointed at the same folder as a repo):

1. **Revive the old `MANAGE_EXTERNAL_STORAGE`-based custom root** (removed in `93e9538` after F-Droid reviewer pushback) -- ruled out. Google Play policy explicitly steers this exact "user picks a folder" scenario toward SAF instead, and F-Droid has already objected to this specific approach on this codebase once.
2. **A SAF-picked-folder mirror** (sync copies in and out of a user-chosen folder) -- works, but needs a sync engine with real failure modes (conflicts, staleness, doubled storage) for every repo that opts in.
3. **A `DocumentsProvider` exposing Gitling's own storage** (this PR) -- zero permissions, no sync engine, never touches git internals (the repo's `.git` stays exactly where JGit already expects it), and covers every repo automatically with no per-repo setup.

This is also a converged-upon pattern, not something novel: Termux hit the same underlying problem (`git` needing real POSIX semantics that break on shared/scoped storage -- their issue was `chmod on .git/config.lock: Operation not permitted`) and independently shipped the same fix, a `DocumentsProvider` over its private git-managed home directory, rather than trying to make git operate on shared storage directly.

## Design

- Document IDs are `repo:<dbId>` (repo root) and `repo:<dbId>/<relative/path>` -- keyed by the repo's stable database ID rather than its folder name, so a persisted grant another app holds survives a repo rename.
- `.git` is hidden from listings and unresolvable by document ID at any depth, including a nested submodule's own `.git` -- repo internals stay unreachable through this provider even from a crafted ID.
- All mutations (write-mode open, create, delete, rename) are refused while the repo's exclusive-task slot is held (`Repo.hasOngoingTask()`, new), so an external app's write can't race a checkout/pull/merge that's rewriting the same files.
- `android:exported="true"` with `android:permission="android.permission.MANAGE_DOCUMENTS"` -- the standard `DocumentsProvider` protection. Only the system's DocumentsUI holds that permission, so no third-party app can call this provider directly; everything goes through the system picker and the per-document grants made there.

## Test plan

Verified live on-device (not just unit-level), both directions:

- [x] Read: the Gitling root appears in the system Files app sidebar and any SAF picker (confirmed via both `ACTION_OPEN_DOCUMENT_TREE` and `ACTION_CREATE_DOCUMENT`); browsing into a repo lists its files with `.git` hidden; opening a file serves the correct content directly through the provider (verified against a known image's actual pixel content, not just "it didn't crash").
- [x] Write: creating a file through the provider via the system's "Save as" flow (exercising `createDocument()`) lands a real file in the real repo directory, and it shows up automatically in Gitling's own Status tab as an untracked change -- no integration code needed on that side, since it's the same working tree JGit already reads.
- [x] `./gradlew --no-daemon clean assembleDebug testDebug` passes.